### PR TITLE
feat(video-player): Add toggleable horizontal playlist and video size controls

### DIFF
--- a/plugins/video-player/frontend/src/VideoPlayer.tsx
+++ b/plugins/video-player/frontend/src/VideoPlayer.tsx
@@ -5,6 +5,8 @@ import type { WorldEntity } from '@ubichill/shared';
 import Hls from 'hls.js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
+    FullscreenExitIcon,
+    FullscreenIcon,
     ListIcon,
     PauseIcon,
     PlayIcon,
@@ -58,6 +60,7 @@ export const VideoPlayer: React.FC<Props> = ({ entity, isLocked, update }) => {
     const [showVideo, setShowVideo] = useState(false);
     const [isLoadingTrack, setIsLoadingTrack] = useState(false);
     const [showPlaylist, setShowPlaylist] = useState(true);
+    const [videoSize, setVideoSize] = useState<'small' | 'medium' | 'large'>('small');
 
     const currentTrack = data.playlist[data.currentIndex];
 
@@ -531,7 +534,7 @@ export const VideoPlayer: React.FC<Props> = ({ entity, isLocked, update }) => {
                 <div className={styles.playerSection}>
                     {/* 動画表示 */}
                     {showVideo && currentTrack && (
-                        <div className={styles.videoDisplay}>
+                        <div className={`${styles.videoDisplay} ${styles[videoSize]}`}>
                             {/* biome-ignore lint/a11y/useMediaCaption: Visualizer only */}
                             <video
                                 ref={videoRef}
@@ -656,13 +659,37 @@ export const VideoPlayer: React.FC<Props> = ({ entity, isLocked, update }) => {
                                     onChange={handleVolumeChange}
                                 />
                                 {currentTrack && (
-                                    <button
-                                        type="button"
-                                        className={`${styles.controlBtn} ${showVideo ? styles.active : ''}`}
-                                        onClick={() => setShowVideo(!showVideo)}
-                                    >
-                                        <VideoIcon size={16} />
-                                    </button>
+                                    <>
+                                        <button
+                                            type="button"
+                                            className={`${styles.controlBtn} ${showVideo ? styles.active : ''}`}
+                                            onClick={() => setShowVideo(!showVideo)}
+                                        >
+                                            <VideoIcon size={16} />
+                                        </button>
+                                        {showVideo && (
+                                            <button
+                                                type="button"
+                                                className={styles.controlBtn}
+                                                onClick={() => {
+                                                    setVideoSize((prev) =>
+                                                        prev === 'small'
+                                                            ? 'medium'
+                                                            : prev === 'medium'
+                                                              ? 'large'
+                                                              : 'small',
+                                                    );
+                                                }}
+                                                title={`動画サイズ: ${videoSize === 'small' ? '小' : videoSize === 'medium' ? '中' : '大'}`}
+                                            >
+                                                {videoSize === 'large' ? (
+                                                    <FullscreenExitIcon size={16} />
+                                                ) : (
+                                                    <FullscreenIcon size={16} />
+                                                )}
+                                            </button>
+                                        )}
+                                    </>
                                 )}
                                 <button
                                     type="button"

--- a/plugins/video-player/frontend/src/icons.tsx
+++ b/plugins/video-player/frontend/src/icons.tsx
@@ -119,3 +119,15 @@ export const ListIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor
         <path d="M3 13h2v-2H3v2zm0 4h2v-2H3v2zm0-8h2V7H3v2zm4 4h14v-2H7v2zm0 4h14v-2H7v2zM7 7v2h14V7H7z" />
     </svg>
 );
+
+export const FullscreenIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={color} className={className}>
+        <path d="M7 14H5v5h5v-2H7v-3zm-2-4h2V7h3V5H5v5zm12 7h-3v2h5v-5h-2v3zM14 5v2h3v3h2V5h-5z" />
+    </svg>
+);
+
+export const FullscreenExitIcon: React.FC<IconProps> = ({ size = 24, color = 'currentColor', className }) => (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill={color} className={className}>
+        <path d="M5 16h3v3h2v-5H5v2zm3-8H5v2h5V5H8v3zm6 11h2v-3h3v-2h-5v5zm2-11V5h-2v5h5V8h-3z" />
+    </svg>
+);

--- a/plugins/video-player/frontend/src/styles.module.css
+++ b/plugins/video-player/frontend/src/styles.module.css
@@ -45,6 +45,19 @@
     display: block;
 }
 
+/* Video Size Variants */
+.videoDisplay.small .videoElement {
+    max-height: 300px;
+}
+
+.videoDisplay.medium .videoElement {
+    max-height: 500px;
+}
+
+.videoDisplay.large .videoElement {
+    max-height: 800px;
+}
+
 /* Player Control Bar */
 .playerControl {
     background: rgba(20, 20, 20, 0.95);


### PR DESCRIPTION
## 概要
ビデオプレイヤーのUIを改善しました：
- プレイリストを横並びレイアウトに変更し、表示/非表示を切り替え可能に
- 動画サイズを3段階（小・中・大）で調整できる機能を追加

## 変更内容
### プレイリスト関連
- ✅ `ListIcon`コンポーネントを追加
- ✅ プレイリストの表示/非表示を制御する`showPlaylist`ステートを追加
- ✅ コントロールバーにプレイリスト切り替えボタンを追加
- ✅ `PlaylistPanel`を`mainContent`の直下に配置して横並びレイアウトを実現

### 動画サイズ関連
- ✅ `FullscreenIcon`と`FullscreenExitIcon`コンポーネントを追加
- ✅ 動画サイズを制御する`videoSize`ステート（small/medium/large）を追加
- ✅ サイズ切り替えボタンを追加（動画表示時のみ表示）
- ✅ CSSで3段階のサイズクラスを定義（300px/500px/800px）

## UIの変更
### Before
- プレイリストが常に表示され縦並び
- 動画サイズが固定（300px）

### After
- プレイリストをボタンで表示/非表示切り替え可能
- プレイヤーコントロールとプレイリストが横並び（flexbox）
- プレイリストは右側に300px幅で表示
- 動画サイズをボタンで切り替え可能（小→中→大→小...）

## コミット履歴
- feat(video-player): Add toggleable horizontal playlist layout
- fix(video-player): Fix playlist horizontal layout structure
- feat(video-player): Add video size toggle (small/medium/large)

## 確認事項
- [x] プレイリストトグルボタンが動作する
- [x] 横並びレイアウトが正しく表示される
- [x] プレイリストの表示/非表示が切り替わる
- [x] 動画サイズ切り替えボタンが動作する
- [x] 動画サイズが3段階で変更される