### PR TITLE
feat: データベース統合と認証システムの実装

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -20,5 +20,5 @@
             "configureZshAsDefaultShell": true
         }
     },
-    "postCreateCommand": "chmod +x .devcontainer/setup.sh && ./.devcontainer/setup.sh"
+    "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/setup.sh && bash .devcontainer/setup.sh"
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -14,22 +14,11 @@ services:
       - "3000:3000"
       - "3001:3001"
   # Database and Redis placeholders (commented out for now as requested)
-  # db:
-  #   image: postgres:15-alpine
-  #   restart: unless-stopped
-  #   environment:
-  #     POSTGRES_PASSWORD: password
-  #     POSTGRES_USER: user
-  #     POSTGRES_DB: ubichill
-  #   volumes:
-  #     - db-data:/var/lib/postgresql/data
-
   # redis:
   #   image: redis:7-alpine
   #   restart: unless-stopped
   #   volumes:
   #     - redis-data:/data
 
-  # volumes:
-  #   db-data:
-  #   redis-data:
+volumes:
+  redis-data:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine AS base
 
-ARG PNPM_VERSION=10.28.2
+ARG PNPM_VERSION=10.29.3
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
-RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+RUN npm install -g --force corepack@latest && corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
 RUN apk add --no-cache libc6-compat
 
 # ==========================================

--- a/charts/ubichill/templates/backend-deployment.yaml
+++ b/charts/ubichill/templates/backend-deployment.yaml
@@ -58,23 +58,58 @@ spec:
           containerPort: {{ .Values.backend.service.targetPort }}
           protocol: TCP
         env:
+        {{- /* PostgreSQL connection configuration */}}
+        {{- if .Values.postgresql.enabled }}
+        {{- if .Values.postgresql.auth.existingSecret }}
+        {{- /* Use PostgreSQL's own existing secret */}}
+        - name: PG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.postgresql.auth.existingSecret }}
+              key: {{ .Values.postgresql.auth.secretKeys.adminPasswordKey | default "postgres-password" }}
+        - name: DATABASE_URL
+          value: "postgresql://postgres:$(PG_PASSWORD)@{{ include "ubichill.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}"
+        {{- else if .Values.backend.existingSecret }}
+        {{- /* Fallback: Use backend's existing secret if PostgreSQL secret is not specified */}}
+        - name: PG_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Values.backend.existingSecret }}
+              key: "postgres-password"
+        - name: DATABASE_URL
+          value: "postgresql://postgres:$(PG_PASSWORD)@{{ include "ubichill.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}"
+        {{- else }}
+        {{- /* Use password from values */}}
+        - name: DATABASE_URL
+          value: "postgresql://postgres:{{ .Values.postgresql.auth.postgresPassword }}@{{ include "ubichill.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}"
+        {{- end }}
+        {{- end }}
         {{- range $key, $value := .Values.backend.env }}
         - name: {{ $key }}
           value: {{ $value | quote }}
+        {{- end }}
+        {{- if and (not .Values.backend.existingSecret) .Values.backend.secretEnv }}
+        {{- range $key, $value := .Values.backend.secretEnv }}
+        - name: {{ $key }}
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "ubichill.fullname" $ }}-backend-secrets
+              key: {{ $key }}
+        {{- end }}
         {{- end }}
         {{- if .Values.worlds.enabled }}
         - name: WORLDS_DIR
           value: "/app/worlds"
         {{- end }}
-        # Database connections
-        {{- if .Values.postgresql.enabled }}
-        - name: DATABASE_URL
-          value: "postgresql://postgres:{{ .Values.postgresql.auth.postgresPassword }}@{{ include "ubichill.fullname" . }}-postgresql:5432/{{ .Values.postgresql.auth.database }}"
-        {{- end }}
         # Redis connection
         {{- if .Values.redis.enabled }}
         - name: REDIS_URL
           value: "redis://{{ include "ubichill.fullname" . }}-redis-master:6379"
+        {{- end }}
+        {{- if .Values.backend.existingSecret }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.backend.existingSecret }}
         {{- end }}
         {{- if .Values.backend.healthcheck.enabled }}
         livenessProbe:

--- a/charts/ubichill/templates/backend-secret.yaml
+++ b/charts/ubichill/templates/backend-secret.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.backend.enabled (not .Values.backend.existingSecret) }}
+{{- if .Values.backend.secretEnv }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "ubichill.fullname" . }}-backend-secrets
+  labels:
+    {{- include "ubichill.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.backend.secretEnv }}
+  {{ $key }}: {{ $value | toString | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/ubichill/templates/frontend-deployment.yaml
+++ b/charts/ubichill/templates/frontend-deployment.yaml
@@ -65,12 +65,22 @@ spec:
         # Backend URL configuration
         {{- if not (hasKey .Values.frontend.env "NEXT_PUBLIC_BACKEND_URL") }}
         - name: NEXT_PUBLIC_BACKEND_URL
-          value: "{{ if .Values.ingress.enabled }}https://{{ (index .Values.ingress.hosts 0).host }}{{ else }}http://localhost:{{ .Values.backend.service.port }}{{ end }}"
+          value: "{{ if and .Values.ingress.enabled .Values.ingress.hosts }}https://{{ (index .Values.ingress.hosts 0).host }}{{ else }}http://localhost:{{ .Values.backend.service.port }}{{ end }}"
+        {{- end }}
+        # NEXT_PUBLIC_API_URL: browser-side URL via Ingress (public)
+        {{- if not (hasKey .Values.frontend.env "NEXT_PUBLIC_API_URL") }}
+        - name: NEXT_PUBLIC_API_URL
+          value: "{{ if and .Values.ingress.enabled .Values.ingress.hosts }}https://{{ (index .Values.ingress.hosts 0).host }}{{ else }}http://localhost:{{ .Values.backend.service.port }}{{ end }}"
+        {{- end }}
+        # BACKEND_INTERNAL_URL: server-side (SSR) URL via K8s internal DNS (non-public)
+        {{- if not (hasKey .Values.frontend.env "BACKEND_INTERNAL_URL") }}
+        - name: BACKEND_INTERNAL_URL
+          value: "http://{{ include "ubichill.fullname" . }}-backend:{{ .Values.backend.service.port }}"
         {{- end }}
         # Video Player Backend URL configuration
         {{- if not (hasKey .Values.frontend.env "NEXT_PUBLIC_VIDEO_PLAYER_BACKEND_URL") }}
         - name: NEXT_PUBLIC_VIDEO_PLAYER_BACKEND_URL
-          value: "{{ if .Values.ingress.enabled }}https://{{ (index .Values.ingress.hosts 0).host }}/plugin/video-player{{ else }}http://localhost:8000{{ end }}"
+          value: "{{ if and .Values.ingress.enabled .Values.ingress.hosts }}https://{{ (index .Values.ingress.hosts 0).host }}/plugin/video-player{{ else }}http://localhost:8000{{ end }}"
         {{- end }}
         {{- if .Values.frontend.healthcheck.enabled }}
         livenessProbe:

--- a/charts/ubichill/values-dev.yaml
+++ b/charts/ubichill/values-dev.yaml
@@ -34,6 +34,10 @@ backend:
   env:
     NODE_ENV: "development"
     CORS_ORIGIN: "*"  # Allow all origins in Kubernetes dev environment
+    BETTER_AUTH_URL: "http://localhost:3001"
+  secretEnv:
+    BETTER_AUTH_SECRET: "dev-secret-key"
+    RESEND_API_KEY: "dev-resend-key"
 
 # Frontend configuration for development  
 frontend:
@@ -75,9 +79,9 @@ redis:
         memory: 64Mi
         cpu: 50m
 
-# Disable PostgreSQL for dev (use SQLite or external DB)
+# Enable PostgreSQL for dev
 postgresql:
-  enabled: false
+  enabled: true
   global:
     imageRegistry: ""
 

--- a/charts/ubichill/values-prod.yaml
+++ b/charts/ubichill/values-prod.yaml
@@ -34,6 +34,10 @@ backend:
   env:
     NODE_ENV: "production"
     CORS_ORIGIN: "https://ubichill.com"
+    BETTER_AUTH_URL: "https://api.ubichill.com"
+  secretEnv:
+    BETTER_AUTH_SECRET: "replace-in-production-vault"
+    RESEND_API_KEY: "replace-in-production-vault"
 
 # Frontend configuration for production
 frontend:

--- a/charts/ubichill/values.yaml
+++ b/charts/ubichill/values.yaml
@@ -99,7 +99,16 @@ backend:
     NODE_ENV: "production"
     PORT: "3001"
     CORS_ORIGIN: "http://localhost:3000"
+    BETTER_AUTH_URL: "http://localhost:3001"
     # Database and Redis connections set by templates
+
+  # Secret environment variables (rendered as Secret)
+  secretEnv:
+    BETTER_AUTH_SECRET: "replace-in-production"
+    RESEND_API_KEY: "replace-with-resend-key"
+  
+  # Existing secret containing the secrets (skips secretEnv creation and injects it)
+  existingSecret: ""
 
   # Security context
   securityContext:
@@ -212,16 +221,16 @@ redis:
 
 # Database (optional)
 postgresql:
-  enabled: false  # Enable if using PostgreSQL
+  enabled: true  # Enable if using PostgreSQL
   global:
     imageRegistry: ""
   image:
     registry: ""
     repository: docker.io/bitnami/postgresql
-    tag: 16.2.0-debian-11-r1
   auth:
     enablePostgresUser: true
     postgresPassword: "ubichill-db-secret"
+    existingSecret: ""
     database: "ubichill"
   primary:
     persistence:

--- a/packages/backend/.env.example
+++ b/packages/backend/.env.example
@@ -23,3 +23,15 @@ RATE_LIMIT_MAX_REQUESTS=100
 
 # デバッグログ出力（true/false）
 DEBUG=false
+
+# Database
+DATABASE_URL="postgresql://ubichill:password@127.0.0.1:5433/ubichill"
+REDIS_URL="redis://127.0.0.1:6379"
+
+# Better Auth
+BETTER_AUTH_SECRET="ubichill-dev-secret-change-in-production"
+BETTER_AUTH_URL="http://localhost:3001"
+
+# Resend (Email)
+RESEND_API_KEY=
+SKIP_EMAIL_VERIFICATION=true

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -28,17 +28,23 @@
     },
     "dependencies": {
         "@distube/ytdl-core": "^4.16.12",
+        "@ubichill/db": "workspace:*",
         "@ubichill/shared": "workspace:*",
+        "bcryptjs": "^3.0.3",
+        "better-auth": "^1.4.19",
         "cors": "^2.8.5",
         "dotenv": "^17.2.3",
+        "drizzle-orm": "^0.45.1",
         "express": "^5.2.1",
         "express-rate-limit": "^8.2.1",
         "helmet": "^8.1.0",
+        "resend": "^6.9.2",
         "socket.io": "^4.8.3",
         "yaml": "^2.8.2",
         "zod": "^4.3.6"
     },
     "devDependencies": {
+        "@types/bcryptjs": "^3.0.0",
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.13.4",
@@ -46,6 +52,7 @@
         "rimraf": "^6.0.1",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
+        "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "wait-on": "^9.0.3"
     }

--- a/packages/backend/src/handlers/socketHandlers.ts
+++ b/packages/backend/src/handlers/socketHandlers.ts
@@ -31,11 +31,45 @@ type TypedSocket = Socket<ClientToServerEvents, ServerToClientEvents, InterServe
  * ワールド参加イベントを処理
  */
 export function handleWorldJoin(socket: TypedSocket) {
-    return (
-        { worldId, instanceId, user }: { worldId: string; instanceId?: string; user: Omit<User, 'id'> },
+    return async (
+        {
+            worldId,
+            instanceId,
+            password,
+            user,
+        }: { worldId: string; instanceId?: string; password?: string; user: Omit<User, 'id'> },
         callback: (response: { success: boolean; userId?: string; error?: string }) => void,
     ) => {
         logger.debug('world:join イベント受信:', { worldId, instanceId, user, socketId: socket.id });
+
+        // 認証済みユーザー確認（socketAuthMiddleware が先に実行されているはず）
+        const authUser = socket.data.authUser;
+        if (!authUser) {
+            callback({ success: false, error: '認証が必要です' });
+            return;
+        }
+
+        // インスタンスのパスワード検証
+        if (instanceId) {
+            const instance = await instanceManager.getInstance(instanceId);
+            if (!instance) {
+                callback({ success: false, error: 'インスタンスが見つかりません' });
+                return;
+            }
+
+            // パスワード保護されている場合は検証
+            if (instance.access.password) {
+                if (!password) {
+                    callback({ success: false, error: 'パスワードが必要です' });
+                    return;
+                }
+                const isPasswordValid = await instanceManager.verifyInstancePassword(instanceId, password);
+                if (!isPasswordValid) {
+                    callback({ success: false, error: 'パスワードが正しくありません' });
+                    return;
+                }
+            }
+        }
 
         // ワールドIDを検証
         const worldValidation = validateWorldId(worldId);
@@ -45,17 +79,20 @@ export function handleWorldJoin(socket: TypedSocket) {
             return;
         }
 
+        // 表示名: クライアント指定があれば優先（ニックネーム機能）、なければ DB の名前を使用
+        const displayName = user.name?.trim() || authUser.name;
+
         // ユーザー名を検証
-        const usernameValidation = validateUsername(user.name);
+        const usernameValidation = validateUsername(displayName);
         if (!usernameValidation.valid) {
             logger.debug('ユーザー名検証失敗:', usernameValidation.error);
             callback({ success: false, error: usernameValidation.error });
             return;
         }
 
-        // ユーザーオブジェクトを作成
+        // ユーザーオブジェクトを作成（DB由来のIDを使用）
         const newUser: User = {
-            id: socket.id,
+            id: authUser.id, // socket.id ではなく DB の user.id を使用
             ...user,
             name: usernameValidation.data,
             position: user.position || DEFAULTS.INITIAL_POSITION,
@@ -79,7 +116,7 @@ export function handleWorldJoin(socket: TypedSocket) {
 
         // インスタンスのユーザー数を更新
         if (instanceId) {
-            instanceManager.updateUserCount(instanceId, 1);
+            await instanceManager.updateUserCount(instanceId, 1);
         }
 
         // このワールド内の全ユーザーを取得
@@ -97,10 +134,10 @@ export function handleWorldJoin(socket: TypedSocket) {
         // 新しいユーザーにワールドスナップショットを送信（UEP）
         // instanceIdをキーにしてワールド状態を取得（インスタンスごとに独立した状態）
         const entities = getWorldSnapshot(worldStateKey);
-        const environment = instanceManager.getWorldEnvironment(worldValidation.data);
+        const environment = await instanceManager.getWorldEnvironment(worldValidation.data);
 
         // ワールド定義から依存関係を取得
-        const world = worldRegistry.getWorld(worldValidation.data);
+        const world = await worldRegistry.getWorld(worldValidation.data);
         const activePlugins = world?.dependencies?.map((d) => d.name) || [];
 
         // ワールドスナップショット（拡張版）を送信
@@ -234,14 +271,14 @@ export function handleUserUpdate(socket: TypedSocket) {
  * 切断イベントを処理
  */
 export function handleDisconnect(socket: TypedSocket) {
-    return () => {
+    return async () => {
         const worldId = socket.data.worldId;
         const instanceId = socket.data.instanceId;
         const user = userManager.removeUser(socket.id);
 
         // インスタンスのユーザー数を更新
         if (instanceId) {
-            instanceManager.updateUserCount(instanceId, -1);
+            await instanceManager.updateUserCount(instanceId, -1);
         }
 
         if (worldId && user) {
@@ -402,17 +439,21 @@ export function handleEntityDelete(socket: TypedSocket) {
  * @param instanceOrWorldId インスタンスIDまたはワールドID（ワールド状態のキー）
  * @param worldId 環境設定取得用のワールドID
  */
-export function sendWorldSnapshot(socket: TypedSocket, instanceOrWorldId: string, worldId?: string): void {
+export async function sendWorldSnapshot(
+    socket: TypedSocket,
+    instanceOrWorldId: string,
+    worldId?: string,
+): Promise<void> {
     const entities = getWorldSnapshot(instanceOrWorldId);
 
     // WorldIDを解決
     let targetWorldId = worldId;
     if (!targetWorldId) {
-        if (worldRegistry.hasWorld(instanceOrWorldId)) {
+        if (await worldRegistry.hasWorld(instanceOrWorldId)) {
             targetWorldId = instanceOrWorldId;
         } else {
             // インスタンスIDからワールドIDを特定を試みる
-            const instance = instanceManager.getInstance(instanceOrWorldId);
+            const instance = await instanceManager.getInstance(instanceOrWorldId);
             if (instance) {
                 targetWorldId = instance.world.id;
             }
@@ -421,8 +462,8 @@ export function sendWorldSnapshot(socket: TypedSocket, instanceOrWorldId: string
 
     // 環境設定とプラグイン情報を取得
     const finalWorldId = targetWorldId || instanceOrWorldId;
-    const environment = instanceManager.getWorldEnvironment(finalWorldId);
-    const world = worldRegistry.getWorld(finalWorldId);
+    const environment = await instanceManager.getWorldEnvironment(finalWorldId);
+    const world = await worldRegistry.getWorld(finalWorldId);
     const activePlugins = world?.dependencies?.map((d) => d.name) || [];
 
     const snapshotPayload: WorldSnapshotPayload = {

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -19,8 +19,11 @@ import {
     handleVideoPlayerSync,
     handleWorldJoin,
 } from './handlers/socketHandlers';
+import { auth } from './lib/auth';
+import { socketAuthMiddleware } from './middleware/socketAuth';
 import audioRouter from './routes/audio';
 import instancesRouter from './routes/instances';
+import usersRouter from './routes/users';
 import worldsRouter from './routes/worlds';
 import { worldRegistry } from './services/worldRegistry';
 
@@ -59,11 +62,26 @@ app.get('/health', (_req, res) => {
 // オーディオAPI（YouTube音楽ストリーム）
 app.use('/api/audio', audioRouter);
 
+import { toNodeHandler } from 'better-auth/node';
+
+// 認証APIのデバッグログ
+app.use('/api/auth', (req, _res, next) => {
+    console.log(`🔐 Auth リクエスト: ${req.method} ${req.originalUrl}`);
+    if (req.method === 'POST') {
+        console.log(`   Body:`, JSON.stringify(req.body, null, 2));
+    }
+    next();
+});
+
+// 認証API（Better Auth）- CORSとプリフライトを確実に処理するため、先に配置
+app.use('/api/auth', toNodeHandler(auth));
+
 // ============================================
 // REST API ルート
 // ============================================
 app.use('/api/v1/worlds', worldsRouter);
 app.use('/api/v1/instances', instancesRouter);
+app.use('/api/v1/users', usersRouter);
 
 // HTTPサーバーを作成
 const server = http.createServer(app);
@@ -77,9 +95,15 @@ const io = new Server<ClientToServerEvents, ServerToClientEvents, InterServerEve
     },
 });
 
-// Socket.IOの接続処理
+// ============================================
+// Socket.IO 認証ミドルウェア（接続時に better-auth 検証）
+// ============================================
+io.use(socketAuthMiddleware);
+
+// Socket.IO 接続ハンドラー
 io.on('connection', (socket) => {
-    console.log(`🔌 新しい接続: ${socket.id.substring(0, 8)}`);
+    const authUser = socket.data.authUser;
+    console.log(`🔌 新しい接続: ${socket.id.substring(0, 8)} (user: ${authUser?.name ?? 'unknown'})`);
 
     // 既存イベントハンドラー
     socket.on('world:join', handleWorldJoin(socket));
@@ -103,13 +127,16 @@ async function startServer() {
     // ワールド定義を読み込み
     await worldRegistry.loadWorlds();
 
+    // ワールド数を取得（非同期）
+    const worlds = await worldRegistry.listWorlds();
+
     server.listen(appConfig.port, () => {
         console.log('');
         console.log('🚀 Ubichill サーバー起動');
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
         console.log(`   🌐 ポート ${appConfig.port} で起動中`);
         console.log(`   📍 環境: ${appConfig.nodeEnv}`);
-        console.log(`   📁 ワールド数: ${worldRegistry.listWorlds().length}`);
+        console.log(`   📁 ワールド数: ${worlds.length}`);
         console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
         console.log('');
     });

--- a/packages/backend/src/lib/auth.ts
+++ b/packages/backend/src/lib/auth.ts
@@ -1,0 +1,256 @@
+import { randomInt } from 'node:crypto';
+import { accounts, db, sessions, users, verifications } from '@ubichill/db';
+import { betterAuth } from 'better-auth';
+import { drizzleAdapter } from 'better-auth/adapters/drizzle';
+import { eq } from 'drizzle-orm';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+
+// 仮登録データを保持（メモリ内、本番ではRedisなどを使用）
+interface PendingRegistration {
+    email: string;
+    password: string;
+    username: string;
+    otp: string;
+    expiresAt: number;
+}
+export const pendingRegistrations = new Map<string, PendingRegistration>();
+
+// OTPを生成（暗号学的に安全な乱数を使用）
+export function generateOTP(): string {
+    return randomInt(100000, 1000000).toString();
+}
+
+// 環境変数でメール確認を無効化できるようにする
+const SKIP_EMAIL_VERIFICATION = process.env.SKIP_EMAIL_VERIFICATION === 'true';
+
+// 仮登録を作成してOTPを送信
+export async function createPendingRegistration(
+    email: string,
+    password: string,
+    username: string,
+): Promise<{ success: boolean; error?: string; skipVerification?: boolean }> {
+    // 既存ユーザーチェック
+    const existingUser = await db.query.users.findFirst({
+        where: eq(users.email, email),
+    });
+    if (existingUser) {
+        return { success: false, error: 'このメールアドレスは既に登録されています' };
+    }
+
+    // ユーザー名の重複チェック
+    const existingUsername = await db.query.users.findFirst({
+        where: eq(users.username, username),
+    });
+    if (existingUsername) {
+        return { success: false, error: 'このユーザー名は既に使用されています' };
+    }
+
+    // メール確認をスキップする場合は直接登録
+    if (SKIP_EMAIL_VERIFICATION) {
+        console.log(`⚠️ メール確認をスキップして直接登録: ${email}`);
+        try {
+            const result = await auth.api.signUpEmail({
+                body: {
+                    email,
+                    password,
+                    name: username,
+                },
+            });
+
+            if (!result) {
+                return { success: false, error: '登録に失敗しました' };
+            }
+
+            // メール確認済みに設定
+            await db.update(users).set({ emailVerified: true, username }).where(eq(users.email, email));
+
+            console.log(`✅ ユーザー登録完了（メール確認スキップ）: ${email}`);
+            return { success: true, skipVerification: true };
+        } catch (error) {
+            console.error('Registration error:', error);
+            return { success: false, error: '登録に失敗しました' };
+        }
+    }
+
+    const otp = generateOTP();
+    const expiresAt = Date.now() + 10 * 60 * 1000; // 10分
+
+    // 既存の仮登録を削除（同じメールアドレスで再登録可能に）
+    pendingRegistrations.delete(email);
+
+    pendingRegistrations.set(email, {
+        email,
+        password,
+        username,
+        otp,
+        expiresAt,
+    });
+
+    // OTPをメールで送信
+    console.log(`📧 OTP送信: ${email}`);
+    if (process.env.NODE_ENV === 'development') {
+        console.log(`   OTP: ${otp}`);
+    } else {
+        // 本番環境ではOTPの値をログに出さない（セキュリティリスク）
+        console.log('   OTP: [REDACTED]');
+    }
+    try {
+        const result = await resend.emails.send({
+            from: 'Ubichill <noreply@youkan.uk>',
+            to: email,
+            subject: `【Ubichill】${username} さんの認証コード`,
+            text: `${username} さん、Ubichill へようこそ！
+
+あなたの認証コード:
+
+${otp}
+
+このコードは10分間有効です。
+
+---
+このメールは ${email} 宛に送信されました。
+心当たりがない場合は、このメールを無視してください。`,
+        });
+        console.log(`   ✅ OTP送信成功:`, result);
+        return { success: true };
+    } catch (error) {
+        console.error(`   ❌ OTP送信失敗:`, error);
+        pendingRegistrations.delete(email);
+        return { success: false, error: 'メールの送信に失敗しました' };
+    }
+}
+
+// OTPを検証して本登録
+export async function verifyAndRegister(email: string, otp: string): Promise<{ success: boolean; error?: string }> {
+    const pending = pendingRegistrations.get(email);
+
+    if (!pending) {
+        return { success: false, error: '仮登録が見つかりません。もう一度登録してください。' };
+    }
+
+    if (Date.now() > pending.expiresAt) {
+        pendingRegistrations.delete(email);
+        return { success: false, error: '認証コードの有効期限が切れました。もう一度登録してください。' };
+    }
+
+    if (pending.otp !== otp) {
+        return { success: false, error: '認証コードが正しくありません' };
+    }
+
+    // 本登録実行
+    try {
+        const result = await auth.api.signUpEmail({
+            body: {
+                email: pending.email,
+                password: pending.password,
+                name: pending.username,
+            },
+        });
+
+        if (!result) {
+            return { success: false, error: '登録に失敗しました' };
+        }
+
+        // メール確認済みに設定
+        await db.update(users).set({ emailVerified: true, username: pending.username }).where(eq(users.email, email));
+
+        pendingRegistrations.delete(email);
+        console.log(`✅ ユーザー登録完了: ${email}`);
+        return { success: true };
+    } catch (error) {
+        console.error('Registration error:', error);
+        return { success: false, error: '登録に失敗しました' };
+    }
+}
+
+// OTPを再送信
+export async function resendOTP(email: string): Promise<{ success: boolean; error?: string }> {
+    const pending = pendingRegistrations.get(email);
+
+    if (!pending) {
+        return { success: false, error: '仮登録が見つかりません。もう一度登録してください。' };
+    }
+
+    const otp = generateOTP();
+    pending.otp = otp;
+    pending.expiresAt = Date.now() + 10 * 60 * 1000;
+
+    console.log(`📧 OTP再送信: ${email}`);
+    if (process.env.NODE_ENV === 'development') {
+        console.log(`   OTP: ${otp}`);
+    } else {
+        // 本番環境ではOTPの値をログに出さない（セキュリティリスク）
+        console.log('   OTP: [REDACTED]');
+    }
+    try {
+        await resend.emails.send({
+            from: 'Ubichill <noreply@youkan.uk>',
+            to: email,
+            subject: `【Ubichill】${pending.username} さんの認証コード（再送信）`,
+            text: `${pending.username} さん
+
+新しい認証コード:
+
+${otp}
+
+このコードは10分間有効です。
+
+---
+このメールは ${email} 宛に送信されました。
+心当たりがない場合は、このメールを無視してください。`,
+        });
+        return { success: true };
+    } catch (error) {
+        console.error(`   ❌ OTP再送信失敗:`, error);
+        return { success: false, error: 'メールの送信に失敗しました' };
+    }
+}
+
+// デバッグ: 起動時に設定を確認
+console.log('🔐 Better Auth 初期化中...');
+console.log(`   RESEND_API_KEY: ${process.env.RESEND_API_KEY ? '設定済み' : '❌ 未設定'}`);
+console.log(`   BETTER_AUTH_URL: ${process.env.BETTER_AUTH_URL || 'http://localhost:3001'}`);
+console.log(`   CORS_ORIGIN: ${process.env.CORS_ORIGIN || 'http://localhost:3000'}`);
+console.log(`   SKIP_EMAIL_VERIFICATION: ${SKIP_EMAIL_VERIFICATION ? '✅ 有効（メール確認スキップ）' : '無効'}`);
+
+export const auth = betterAuth({
+    database: drizzleAdapter(db, {
+        provider: 'pg',
+        schema: {
+            user: users,
+            session: sessions,
+            account: accounts,
+            verification: verifications,
+        },
+    }),
+    baseURL: process.env.BETTER_AUTH_URL || 'http://localhost:3001',
+    trustedOrigins: (process.env.CORS_ORIGIN || 'http://localhost:3000').split(',').map((o) => o.trim()),
+    emailAndPassword: {
+        enabled: true,
+        requireEmailVerification: false, // カスタムOTPフローで確認するので無効化
+    },
+    session: {
+        expiresIn: 60 * 60 * 24 * 7, // 7 days
+        updateAge: 60 * 60 * 24, // 1 day
+        cookieCache: {
+            enabled: true,
+            maxAge: 60 * 5, // 5 minutes
+        },
+    },
+    user: {
+        additionalFields: {
+            username: {
+                type: 'string',
+                required: false,
+            },
+            profileImageUrl: {
+                type: 'string',
+                required: false,
+            },
+        },
+    },
+});
+
+export type Session = typeof auth.$Infer.Session;

--- a/packages/backend/src/middleware/auth.ts
+++ b/packages/backend/src/middleware/auth.ts
@@ -1,0 +1,109 @@
+import type { NextFunction, Request, Response } from 'express';
+import { auth } from '../lib/auth';
+
+// Extend Express Request type with user info
+declare global {
+    namespace Express {
+        interface Request {
+            user?: {
+                id: string;
+                email: string;
+                name: string;
+                emailVerified: boolean;
+                image?: string | null;
+            };
+            session?: {
+                id: string;
+                userId: string;
+                token: string;
+                expiresAt: Date;
+            };
+        }
+    }
+}
+
+/**
+ * 認証必須ミドルウェア
+ * セッションがない場合は401を返す
+ */
+export async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+        const session = await auth.api.getSession({
+            headers: new Headers(
+                Object.entries(req.headers).reduce(
+                    (acc, [key, value]) => {
+                        if (value) acc[key] = Array.isArray(value) ? value.join(', ') : value;
+                        return acc;
+                    },
+                    {} as Record<string, string>,
+                ),
+            ),
+        });
+
+        if (!session) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
+
+        // リクエストにユーザー情報を追加
+        req.user = {
+            id: session.user.id,
+            email: session.user.email,
+            name: session.user.name,
+            emailVerified: session.user.emailVerified,
+            image: session.user.image,
+        };
+        req.session = {
+            id: session.session.id,
+            userId: session.session.userId,
+            token: session.session.token,
+            expiresAt: session.session.expiresAt,
+        };
+
+        next();
+    } catch (error) {
+        console.error('Auth middleware error:', error);
+        res.status(401).json({ error: 'Unauthorized' });
+    }
+}
+
+/**
+ * オプション認証ミドルウェア
+ * セッションがあればユーザー情報を追加、なくても通過
+ */
+export async function optionalAuth(req: Request, _res: Response, next: NextFunction): Promise<void> {
+    try {
+        const session = await auth.api.getSession({
+            headers: new Headers(
+                Object.entries(req.headers).reduce(
+                    (acc, [key, value]) => {
+                        if (value) acc[key] = Array.isArray(value) ? value.join(', ') : value;
+                        return acc;
+                    },
+                    {} as Record<string, string>,
+                ),
+            ),
+        });
+
+        if (session) {
+            req.user = {
+                id: session.user.id,
+                email: session.user.email,
+                name: session.user.name,
+                emailVerified: session.user.emailVerified,
+                image: session.user.image,
+            };
+            req.session = {
+                id: session.session.id,
+                userId: session.session.userId,
+                token: session.session.token,
+                expiresAt: session.session.expiresAt,
+            };
+        }
+
+        next();
+    } catch {
+        // 認証失敗しても通過
+        next();
+    }
+}

--- a/packages/backend/src/middleware/socketAuth.ts
+++ b/packages/backend/src/middleware/socketAuth.ts
@@ -1,0 +1,58 @@
+import type { ClientToServerEvents, InterServerEvents, ServerToClientEvents, SocketData } from '@ubichill/shared';
+import type { Socket } from 'socket.io';
+import { auth } from '../lib/auth';
+import { logger } from '../utils/logger';
+
+type TypedSocket = Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>;
+
+/**
+ * Socket.IO 接続時の認証ミドルウェア
+ *
+ * WebSocket ハンドシェイク時のリクエストヘッダー（Cookie含む）から
+ * better-auth セッションを検証し、認証済みユーザー情報を socket.data に格納する。
+ * 未認証の場合は接続を拒否する。
+ *
+ * @example
+ *   io.use(socketAuthMiddleware);
+ */
+export async function socketAuthMiddleware(socket: TypedSocket, next: (err?: Error) => void): Promise<void> {
+    try {
+        // ハンドシェイク時のヘッダーを Web 標準の Headers に変換
+        const rawHeaders = socket.handshake.headers;
+        const headers = new Headers(
+            Object.entries(rawHeaders).reduce(
+                (acc, [key, value]) => {
+                    if (value) acc[key] = Array.isArray(value) ? value.join(', ') : value;
+                    return acc;
+                },
+                {} as Record<string, string>,
+            ),
+        );
+
+        // better-auth でセッションを検証
+        const session = await auth.api.getSession({ headers });
+
+        if (!session) {
+            logger.warn(`🔒 WebSocket 認証失敗 (未認証): ${socket.id.substring(0, 8)}`);
+            next(new Error('Unauthorized'));
+            return;
+        }
+
+        // 認証済みユーザー情報を socket.data に格納（以降のハンドラーで利用可能）
+        socket.data.authUser = {
+            id: session.user.id,
+            email: session.user.email,
+            name: session.user.name,
+            image: session.user.image ?? null,
+        };
+
+        logger.debug(
+            `🔓 WebSocket 認証成功: user=${session.user.name} (${session.user.id.substring(0, 8)}) socket=${socket.id.substring(0, 8)}`,
+        );
+
+        next();
+    } catch (error) {
+        logger.error('WebSocket 認証ミドルウェアエラー:', error);
+        next(new Error('Unauthorized'));
+    }
+}

--- a/packages/backend/src/routes/users.ts
+++ b/packages/backend/src/routes/users.ts
@@ -1,0 +1,109 @@
+import { db, users } from '@ubichill/db';
+import { eq } from 'drizzle-orm';
+import { Router } from 'express';
+import { createPendingRegistration, resendOTP, verifyAndRegister } from '../lib/auth';
+
+const router = Router();
+
+// 仮登録（OTP送信）
+router.post('/register', async (req, res) => {
+    const { email, password, username } = req.body;
+
+    if (!email || !password || !username) {
+        return res.status(400).json({ error: 'メールアドレス、パスワード、ユーザー名は必須です' });
+    }
+
+    if (password.length < 8) {
+        return res.status(400).json({ error: 'パスワードは8文字以上で入力してください' });
+    }
+
+    const trimmedUsername = username.trim();
+    if (trimmedUsername.length < 1 || trimmedUsername.length > 30) {
+        return res.status(400).json({ error: 'ユーザー名は1〜30文字で入力してください' });
+    }
+
+    const result = await createPendingRegistration(email, password, trimmedUsername);
+
+    if (!result.success) {
+        return res.status(400).json({ error: result.error });
+    }
+
+    // メール確認をスキップした場合
+    if (result.skipVerification) {
+        return res.json({
+            success: true,
+            skipVerification: true,
+            message: '登録が完了しました。ログインしてください。',
+        });
+    }
+
+    return res.json({ success: true, message: '認証コードをメールに送信しました' });
+});
+
+// OTP検証して本登録
+router.post('/verify', async (req, res) => {
+    const { email, otp } = req.body;
+
+    if (!email || !otp) {
+        return res.status(400).json({ error: 'メールアドレスと認証コードは必須です' });
+    }
+
+    const result = await verifyAndRegister(email, otp);
+
+    if (!result.success) {
+        return res.status(400).json({ error: result.error });
+    }
+
+    return res.json({ success: true, message: '登録が完了しました' });
+});
+
+// OTP再送信
+router.post('/resend-otp', async (req, res) => {
+    const { email } = req.body;
+
+    if (!email) {
+        return res.status(400).json({ error: 'メールアドレスは必須です' });
+    }
+
+    const result = await resendOTP(email);
+
+    if (!result.success) {
+        return res.status(400).json({ error: result.error });
+    }
+
+    return res.json({ success: true, message: '認証コードを再送信しました' });
+});
+
+// ユーザー名の重複チェック
+router.get('/check-username', async (req, res) => {
+    const { username } = req.query;
+
+    if (!username || typeof username !== 'string') {
+        return res.status(400).json({ error: 'Username is required' });
+    }
+
+    // ユーザー名の長さチェック（1-30文字）
+    const trimmedUsername = username.trim();
+    if (trimmedUsername.length < 1 || trimmedUsername.length > 30) {
+        return res.status(400).json({
+            available: false,
+            error: 'ユーザー名は1〜30文字で入力してください',
+        });
+    }
+
+    try {
+        const existingUser = await db.query.users.findFirst({
+            where: eq(users.username, trimmedUsername),
+        });
+
+        return res.json({
+            available: !existingUser,
+            error: existingUser ? 'このユーザー名は既に使用されています' : null,
+        });
+    } catch (error) {
+        console.error('Username check error:', error);
+        return res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+export default router;

--- a/packages/backend/src/routes/worlds.ts
+++ b/packages/backend/src/routes/worlds.ts
@@ -1,39 +1,192 @@
+import { WorldDefinitionSchema } from '@ubichill/shared';
 import { Router } from 'express';
+import { requireAuth } from '../middleware/auth';
 import { worldRegistry } from '../services/worldRegistry';
 
 const router = Router();
 
 /**
  * GET /api/v1/worlds
- * ワールドテンプレート一覧を取得
+ * ワールドテンプレート一覧を取得（認証必須）
  */
-router.get('/', (_req, res) => {
-    const worlds = worldRegistry.listWorlds().map((world) => ({
-        id: world.id,
-        displayName: world.displayName,
-        description: world.description,
-        thumbnail: world.thumbnail,
-        version: world.version,
-        capacity: world.capacity,
-    }));
+router.get('/', requireAuth, async (_req, res) => {
+    try {
+        const worlds = await worldRegistry.listWorlds();
+        const response = worlds.map((world) => ({
+            id: world.id,
+            displayName: world.displayName,
+            description: world.description,
+            thumbnail: world.thumbnail,
+            version: world.version,
+            capacity: world.capacity,
+        }));
 
-    res.json({ worlds });
+        res.json({ worlds: response });
+    } catch (error) {
+        console.error('ワールド一覧取得エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
 });
 
 /**
  * GET /api/v1/worlds/:worldId
- * ワールドテンプレート詳細を取得
+ * ワールドテンプレート詳細を取得（認証必須）
  */
-router.get('/:worldId', (req, res) => {
-    const { worldId } = req.params;
-    const world = worldRegistry.getWorld(worldId);
+router.get('/:worldId', requireAuth, async (req, res) => {
+    try {
+        const worldId = req.params.worldId as string;
+        const world = await worldRegistry.getWorld(worldId);
 
-    if (!world) {
-        res.status(404).json({ error: 'World not found' });
-        return;
+        if (!world) {
+            res.status(404).json({ error: 'World not found' });
+            return;
+        }
+
+        res.json(world);
+    } catch (error) {
+        console.error('ワールド取得エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
     }
+});
 
-    res.json(world);
+/**
+ * POST /api/v1/worlds
+ * 新しいワールドをアップロード（認証必須）
+ */
+router.post('/', requireAuth, async (req, res) => {
+    try {
+        const result = WorldDefinitionSchema.safeParse(req.body);
+        if (!result.success) {
+            res.status(400).json({
+                error: 'Invalid world definition',
+                details: result.error.issues,
+            });
+            return;
+        }
+
+        const definition = result.data;
+        const worldId = definition.metadata.name;
+
+        // 既存チェック
+        const existing = await worldRegistry.getWorld(worldId);
+        if (existing) {
+            res.status(409).json({ error: 'World already exists', worldId });
+            return;
+        }
+
+        // 認証されたユーザーIDを使用（requireAuthで保証）
+        if (!req.user) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
+        const authorId = req.user.id;
+
+        const world = await worldRegistry.createWorld(authorId, definition);
+        res.status(201).json(world);
+    } catch (error) {
+        console.error('ワールド作成エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+/**
+ * PUT /api/v1/worlds/:worldId
+ * ワールドを更新（認証必須、作成者のみ）
+ */
+router.put('/:worldId', requireAuth, async (req, res) => {
+    try {
+        const worldId = req.params.worldId as string;
+
+        // 認証されたユーザーIDを取得
+        if (!req.user) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
+
+        // ワールドの作成者を確認
+        const worldRecord = await worldRegistry.getWorldRecord(worldId);
+        if (!worldRecord) {
+            res.status(404).json({ error: 'World not found' });
+            return;
+        }
+
+        // 作成者のみ更新可能
+        if (worldRecord.authorId !== req.user.id) {
+            res.status(403).json({ error: 'Forbidden: Only the author can update this world' });
+            return;
+        }
+
+        const result = WorldDefinitionSchema.safeParse(req.body);
+        if (!result.success) {
+            res.status(400).json({
+                error: 'Invalid world definition',
+                details: result.error.issues,
+            });
+            return;
+        }
+
+        const definition = result.data;
+
+        // metadata.name と URL の worldId が一致するか確認
+        if (definition.metadata.name !== worldId) {
+            res.status(400).json({
+                error: 'World ID mismatch',
+                message: 'metadata.name must match the URL worldId',
+            });
+            return;
+        }
+
+        const updated = await worldRegistry.updateWorld(worldId, definition);
+        if (!updated) {
+            res.status(404).json({ error: 'World not found' });
+            return;
+        }
+
+        res.json(updated);
+    } catch (error) {
+        console.error('ワールド更新エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+/**
+ * DELETE /api/v1/worlds/:worldId
+ * ワールドを削除（認証必須、作成者のみ）
+ */
+router.delete('/:worldId', requireAuth, async (req, res) => {
+    try {
+        const worldId = req.params.worldId as string;
+
+        // 認証されたユーザーIDを取得
+        if (!req.user) {
+            res.status(401).json({ error: 'Unauthorized' });
+            return;
+        }
+
+        // ワールドの作成者を確認
+        const worldRecord = await worldRegistry.getWorldRecord(worldId);
+        if (!worldRecord) {
+            res.status(404).json({ error: 'World not found' });
+            return;
+        }
+
+        // 作成者のみ削除可能
+        if (worldRecord.authorId !== req.user.id) {
+            res.status(403).json({ error: 'Forbidden: Only the author can delete this world' });
+            return;
+        }
+
+        const deleted = await worldRegistry.deleteWorld(worldId);
+        if (!deleted) {
+            res.status(404).json({ error: 'World not found' });
+            return;
+        }
+
+        res.status(204).send();
+    } catch (error) {
+        console.error('ワールド削除エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
 });
 
 export default router;

--- a/packages/backend/src/services/instanceManager.ts
+++ b/packages/backend/src/services/instanceManager.ts
@@ -1,85 +1,48 @@
-import { randomUUID } from 'node:crypto';
+import { instanceRepository } from '@ubichill/db';
 import type { CreateInstanceRequest, Instance, InstanceAccess, WorldEnvironmentData } from '@ubichill/shared';
 import { DEFAULTS } from '@ubichill/shared';
+import bcrypt from 'bcryptjs';
 import { worldRegistry } from './worldRegistry';
 import { clearWorldState, createEntity } from './worldState';
 
 /**
- * インスタンス内部状態
- */
-interface InstanceState extends Instance {
-    passwordHash?: string; // パスワード保護用
-}
-
-/**
  * インスタンスマネージャー
- * インスタンスのライフサイクルを管理
+ * インスタンスのライフサイクルを管理（DBベース）
  */
 class InstanceManager {
-    private instances: Map<string, InstanceState> = new Map();
-    // worldId -> Set<instanceId> のマッピング
-    private worldToInstances: Map<string, Set<string>> = new Map();
-
     /**
      * 新しいインスタンスを作成
      */
-    createInstance(request: CreateInstanceRequest, leaderId: string): Instance | { error: string } {
-        const world = worldRegistry.getWorld(request.worldId);
+    async createInstance(request: CreateInstanceRequest, leaderId: string): Promise<Instance | { error: string }> {
+        const world = await worldRegistry.getWorld(request.worldId);
         if (!world) {
             return { error: `World not found: ${request.worldId}` };
         }
 
-        const instanceId = randomUUID();
-        const now = new Date().toISOString();
-
-        const access: InstanceAccess = {
-            type: request.access?.type ?? 'public',
-            tags: request.access?.tags ?? [],
-            password: !!request.access?.password,
-        };
-
         const maxUsers = request.settings?.maxUsers ?? world.capacity.default;
+        const cappedMaxUsers = Math.min(maxUsers, world.capacity.max);
 
-        const instance: InstanceState = {
-            id: instanceId,
-            status: 'active',
-            leaderId,
-            createdAt: now,
-            expiresAt: null, // 無期限
-
-            world: {
-                id: world.id,
-                version: world.version,
-                displayName: world.displayName,
-                thumbnail: world.thumbnail,
-            },
-
-            access,
-            stats: {
-                currentUsers: 0,
-                maxUsers: Math.min(maxUsers, world.capacity.max),
-            },
-            connection: {
-                url: DEFAULTS.WORLD_ID, // 将来的にはサーバーURLを返す
-                namespace: `/${instanceId}`,
-            },
-
-            // 内部状態
-            passwordHash: request.access?.password, // 簡易実装（本番ではハッシュ化）
-        };
-
-        this.instances.set(instanceId, instance);
-
-        // worldId -> instanceId のマッピングを追加
-        if (!this.worldToInstances.has(request.worldId)) {
-            this.worldToInstances.set(request.worldId, new Set());
+        // パスワードがある場合はハッシュ化
+        let passwordHash: string | undefined;
+        if (request.access?.password) {
+            passwordHash = await bcrypt.hash(request.access.password, 10);
         }
-        this.worldToInstances.get(request.worldId)?.add(instanceId);
+
+        // DBにインスタンスを作成（world.dbIdを使用）
+        const dbInstance = await instanceRepository.create({
+            worldId: world.dbId,
+            leaderId,
+            accessType: request.access?.type ?? 'public',
+            accessTags: request.access?.tags ?? [],
+            hasPassword: !!request.access?.password,
+            maxUsers: cappedMaxUsers,
+            passwordHash,
+        });
 
         // インスタンス固有のワールド状態を初期化（initialEntitiesを配置）
         if (world.initialEntities && world.initialEntities.length > 0) {
             for (const entityDef of world.initialEntities) {
-                createEntity(instanceId, {
+                createEntity(dbInstance.id, {
                     type: entityDef.kind,
                     ownerId: null,
                     lockedBy: null,
@@ -96,66 +59,76 @@ class InstanceManager {
                 });
             }
             console.log(
-                `🌍 インスタンス ${instanceId} にinitialEntities ${world.initialEntities.length}件を配置しました`,
+                `🌍 インスタンス ${dbInstance.id} にinitialEntities ${world.initialEntities.length}件を配置しました`,
             );
         }
 
-        console.log(`🏠 インスタンス作成: ${instanceId} (world: ${world.id})`);
+        console.log(`🏠 インスタンス作成: ${dbInstance.id} (world: ${world.id})`);
 
-        return this.toPublicInstance(instance);
+        return this.toPublicInstance(dbInstance, world);
     }
 
     /**
      * インスタンス一覧を取得
      */
-    listInstances(options?: { tag?: string; includeFull?: boolean }): Instance[] {
-        let instances = Array.from(this.instances.values());
+    async listInstances(options?: { tag?: string; includeFull?: boolean }): Promise<Instance[]> {
+        const dbInstances = await instanceRepository.findAll({
+            tag: options?.tag,
+            includeFull: options?.includeFull,
+        });
 
-        // タグでフィルタリング
-        if (options?.tag) {
-            const tag = options.tag;
-            instances = instances.filter((i) => i.access.tags.includes(tag));
+        const instances: Instance[] = [];
+        for (const dbInstance of dbInstances) {
+            const world = await worldRegistry.getWorldByDbId(dbInstance.worldId);
+            if (world) {
+                instances.push(this.toPublicInstance(dbInstance, world));
+            }
         }
 
-        // 満員を除外
-        if (!options?.includeFull) {
-            instances = instances.filter((i) => i.status !== 'full');
-        }
+        return instances;
+    }
 
-        return instances.map((i) => this.toPublicInstance(i));
+    /**
+     * インスタンスのパスワードを検証
+     */
+    async verifyInstancePassword(instanceId: string, password: string): Promise<boolean> {
+        const dbInstance = await instanceRepository.findById(instanceId);
+        if (!dbInstance || !dbInstance.passwordHash) {
+            return false;
+        }
+        return bcrypt.compare(password, dbInstance.passwordHash);
     }
 
     /**
      * インスタンスを取得
      */
-    getInstance(instanceId: string): Instance | undefined {
-        const instance = this.instances.get(instanceId);
-        return instance ? this.toPublicInstance(instance) : undefined;
+    async getInstance(instanceId: string): Promise<Instance | undefined> {
+        const dbInstance = await instanceRepository.findById(instanceId);
+        if (!dbInstance) return undefined;
+
+        const world = await worldRegistry.getWorldByDbId(dbInstance.worldId);
+        if (!world) return undefined;
+
+        return this.toPublicInstance(dbInstance, world);
     }
 
     /**
      * インスタンスを終了
      */
-    closeInstance(instanceId: string, userId: string): { success: boolean; error?: string } {
-        const instance = this.instances.get(instanceId);
-        if (!instance) {
+    async closeInstance(instanceId: string, userId: string): Promise<{ success: boolean; error?: string }> {
+        const dbInstance = await instanceRepository.findById(instanceId);
+        if (!dbInstance) {
             return { success: false, error: 'Instance not found' };
         }
 
-        if (instance.leaderId !== userId) {
+        if (dbInstance.leaderId !== userId) {
             return { success: false, error: 'Only the leader can close the instance' };
         }
 
-        instance.status = 'closing';
-        this.instances.delete(instanceId);
-
-        // マッピングからも削除
-        const worldInstances = this.worldToInstances.get(instance.world.id);
-        if (worldInstances) {
-            worldInstances.delete(instanceId);
-            if (worldInstances.size === 0) {
-                this.worldToInstances.delete(instance.world.id);
-            }
+        // DBから削除
+        const deleted = await instanceRepository.deleteByLeader(instanceId, userId);
+        if (!deleted) {
+            return { success: false, error: 'Failed to delete instance' };
         }
 
         // ワールド状態をクリーンアップ
@@ -170,65 +143,40 @@ class InstanceManager {
      * ユーザー数を更新
      * @returns 更新後のユーザー数。インスタンスが見つからない場合は -1
      */
-    updateUserCount(instanceId: string, delta: number): number {
-        const instance = this.instances.get(instanceId);
-        if (!instance) return -1;
-
-        instance.stats.currentUsers = Math.max(0, instance.stats.currentUsers + delta);
+    async updateUserCount(instanceId: string, delta: number): Promise<number> {
+        const updated = await instanceRepository.updateUserCount(instanceId, delta);
+        if (!updated) return -1;
 
         // ユーザーが0になったらインスタンスを自動削除
-        // ユーザーが0になったらインスタンスを自動削除
-        if (instance.stats.currentUsers === 0) {
-            // 他の処理で既に削除されていないか、最新状態を確認してからクリーンアップする
-            const currentInstance = this.instances.get(instanceId);
-            if (currentInstance && currentInstance.stats.currentUsers === 0) {
-                this.instances.delete(instanceId);
+        if (updated.currentUsers === 0) {
+            await instanceRepository.delete(instanceId);
 
-                // マッピングからも削除
-                const worldInstances = this.worldToInstances.get(currentInstance.world.id);
-                if (worldInstances) {
-                    worldInstances.delete(instanceId);
-                    if (worldInstances.size === 0) {
-                        this.worldToInstances.delete(currentInstance.world.id);
-                    }
-                }
+            // ワールド状態をクリーンアップ
+            clearWorldState(instanceId);
 
-                // ワールド状態をクリーンアップ
-                clearWorldState(instanceId);
-
-                console.log(`🗑️ インスタンス自動削除（ユーザー0）: ${instanceId}`);
-            }
+            console.log(`🗑️ インスタンス自動削除（ユーザー0）: ${instanceId}`);
             return 0;
         }
 
-        // ステータス更新
-        if (instance.stats.currentUsers >= instance.stats.maxUsers) {
-            instance.status = 'full';
-        } else if (instance.status === 'full') {
-            instance.status = 'active';
-        }
-
-        return instance.stats.currentUsers;
+        return updated.currentUsers;
     }
 
     /**
      * ワールドIDからインスタンスを検索（既存インスタンスへの参加用）
      */
-    findInstancesByWorld(worldId: string): Instance[] {
-        const instanceIds = this.worldToInstances.get(worldId);
-        if (!instanceIds) return [];
+    async findInstancesByWorld(worldId: string): Promise<Instance[]> {
+        const world = await worldRegistry.getWorld(worldId);
+        if (!world) return [];
 
-        return Array.from(instanceIds)
-            .map((id) => this.instances.get(id))
-            .filter((i): i is InstanceState => !!i)
-            .map((i) => this.toPublicInstance(i));
+        const dbInstances = await instanceRepository.findByWorldId(world.dbId);
+        return dbInstances.map((dbInstance) => this.toPublicInstance(dbInstance, world));
     }
 
     /**
      * ワールドの環境設定を取得
      */
-    getWorldEnvironment(worldId: string): WorldEnvironmentData {
-        const world = worldRegistry.getWorld(worldId);
+    async getWorldEnvironment(worldId: string): Promise<WorldEnvironmentData> {
+        const world = await worldRegistry.getWorld(worldId);
         if (world) {
             // undefined を null に変換
             return {
@@ -242,12 +190,42 @@ class InstanceManager {
     }
 
     /**
-     * 内部状態から公開用のInstanceオブジェクトに変換
+     * DB record から公開用のInstanceオブジェクトに変換
      */
-    private toPublicInstance(instance: InstanceState): Instance {
-        // passwordHash を除外
-        const { passwordHash: _, ...publicInstance } = instance;
-        return publicInstance;
+    private toPublicInstance(
+        dbInstance: Awaited<ReturnType<typeof instanceRepository.findById>> & object,
+        world: { id: string; version: string; displayName: string; thumbnail?: string },
+    ): Instance {
+        const access: InstanceAccess = {
+            type: dbInstance.accessType,
+            tags: dbInstance.accessTags ?? [],
+            password: dbInstance.hasPassword,
+        };
+
+        return {
+            id: dbInstance.id,
+            status: dbInstance.status,
+            leaderId: dbInstance.leaderId,
+            createdAt: dbInstance.createdAt.toISOString(),
+            expiresAt: dbInstance.expiresAt?.toISOString() ?? null,
+
+            world: {
+                id: world.id,
+                version: world.version,
+                displayName: world.displayName,
+                thumbnail: world.thumbnail,
+            },
+
+            access,
+            stats: {
+                currentUsers: dbInstance.currentUsers,
+                maxUsers: dbInstance.maxUsers,
+            },
+            connection: {
+                url: DEFAULTS.WORLD_ID, // 将来的にはサーバーURLを返す
+                namespace: `/${dbInstance.id}`,
+            },
+        };
     }
 }
 

--- a/packages/db/docker-compose.yml
+++ b/packages/db/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: password
+      POSTGRES_USER: ubichill
+      POSTGRES_DB: ubichill
+    ports:
+      - "5433:5432"
+    volumes:
+      - db-data:/var/lib/postgresql/data
+
+volumes:
+  db-data:

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'drizzle-kit';
+
+export default defineConfig({
+    schema: './src/schema/*',
+    out: './drizzle',
+    dialect: 'postgresql',
+    dbCredentials: {
+        url: process.env.DATABASE_URL || 'postgresql://ubichill:password@127.0.0.1:5433/ubichill',
+    },
+});

--- a/packages/db/drizzle/0000_init_schema.sql
+++ b/packages/db/drizzle/0000_init_schema.sql
@@ -1,0 +1,112 @@
+CREATE TYPE "public"."instance_access_type" AS ENUM('public', 'friend_plus', 'friend_only', 'invite_only');--> statement-breakpoint
+CREATE TYPE "public"."instance_status" AS ENUM('active', 'full', 'closing');--> statement-breakpoint
+CREATE TYPE "public"."friend_status" AS ENUM('pending', 'accepted');--> statement-breakpoint
+CREATE TABLE "instances" (
+	"id" varchar(21) PRIMARY KEY NOT NULL,
+	"world_id" varchar(21) NOT NULL,
+	"leader_id" text NOT NULL,
+	"status" "instance_status" DEFAULT 'active' NOT NULL,
+	"access_type" "instance_access_type" DEFAULT 'public' NOT NULL,
+	"access_tags" jsonb DEFAULT '[]'::jsonb,
+	"has_password" boolean DEFAULT false NOT NULL,
+	"max_users" integer DEFAULT 10 NOT NULL,
+	"current_users" integer DEFAULT 0 NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"expires_at" timestamp,
+	"password_hash" varchar(255)
+);
+--> statement-breakpoint
+CREATE TABLE "accounts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"account_id" text NOT NULL,
+	"provider_id" text NOT NULL,
+	"user_id" text NOT NULL,
+	"access_token" text,
+	"refresh_token" text,
+	"id_token" text,
+	"access_token_expires_at" timestamp,
+	"refresh_token_expires_at" timestamp,
+	"scope" text,
+	"password" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sessions" (
+	"id" text PRIMARY KEY NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"token" text NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"ip_address" text,
+	"user_agent" text,
+	"user_id" text NOT NULL,
+	CONSTRAINT "sessions_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "user_favorites" (
+	"user_id" text NOT NULL,
+	"world_id" varchar(21) NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_favorites_user_id_world_id_pk" PRIMARY KEY("user_id","world_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_friends" (
+	"user_id" text NOT NULL,
+	"friend_id" text NOT NULL,
+	"status" "friend_status" DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "user_friends_user_id_friend_id_pk" PRIMARY KEY("user_id","friend_id")
+);
+--> statement-breakpoint
+CREATE TABLE "user_settings" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"disable_external_urls" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "users" (
+	"id" text PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"email_verified" boolean DEFAULT false NOT NULL,
+	"image" text,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	"username" varchar(255),
+	"profile_image_url" varchar(1024),
+	CONSTRAINT "users_email_unique" UNIQUE("email"),
+	CONSTRAINT "users_username_unique" UNIQUE("username")
+);
+--> statement-breakpoint
+CREATE TABLE "verifications" (
+	"id" text PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expires_at" timestamp NOT NULL,
+	"created_at" timestamp DEFAULT now(),
+	"updated_at" timestamp DEFAULT now()
+);
+--> statement-breakpoint
+CREATE TABLE "worlds" (
+	"id" varchar(21) PRIMARY KEY NOT NULL,
+	"author_id" text NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"version" varchar(50) NOT NULL,
+	"definition" jsonb NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "worlds_name_unique" UNIQUE("name")
+);
+--> statement-breakpoint
+ALTER TABLE "instances" ADD CONSTRAINT "instances_world_id_worlds_id_fk" FOREIGN KEY ("world_id") REFERENCES "public"."worlds"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "instances" ADD CONSTRAINT "instances_leader_id_users_id_fk" FOREIGN KEY ("leader_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "accounts" ADD CONSTRAINT "accounts_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "sessions" ADD CONSTRAINT "sessions_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_favorites" ADD CONSTRAINT "user_favorites_world_id_worlds_id_fk" FOREIGN KEY ("world_id") REFERENCES "public"."worlds"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_friends" ADD CONSTRAINT "user_friends_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_friends" ADD CONSTRAINT "user_friends_friend_id_users_id_fk" FOREIGN KEY ("friend_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "user_settings" ADD CONSTRAINT "user_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "worlds" ADD CONSTRAINT "worlds_author_id_users_id_fk" FOREIGN KEY ("author_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/packages/db/drizzle/meta/0000_snapshot.json
+++ b/packages/db/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,771 @@
+{
+  "id": "25adba85-1405-495e-8ff7-958dc81d43bb",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.instances": {
+      "name": "instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "world_id": {
+          "name": "world_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leader_id": {
+          "name": "leader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "instance_access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "access_tags": {
+          "name": "access_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "has_password": {
+          "name": "has_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "current_users": {
+          "name": "current_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "instances_world_id_worlds_id_fk": {
+          "name": "instances_world_id_worlds_id_fk",
+          "tableFrom": "instances",
+          "tableTo": "worlds",
+          "columnsFrom": [
+            "world_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "instances_leader_id_users_id_fk": {
+          "name": "instances_leader_id_users_id_fk",
+          "tableFrom": "instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "leader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world_id": {
+          "name": "world_id",
+          "type": "varchar(21)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_favorites_world_id_worlds_id_fk": {
+          "name": "user_favorites_world_id_worlds_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "worlds",
+          "columnsFrom": [
+            "world_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_world_id_pk": {
+          "name": "user_favorites_user_id_world_id_pk",
+          "columns": [
+            "user_id",
+            "world_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_friends": {
+      "name": "user_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friend_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_friends_user_id_users_id_fk": {
+          "name": "user_friends_user_id_users_id_fk",
+          "tableFrom": "user_friends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_friends_friend_id_users_id_fk": {
+          "name": "user_friends_friend_id_users_id_fk",
+          "tableFrom": "user_friends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_friends_user_id_friend_id_pk": {
+          "name": "user_friends_user_id_friend_id_pk",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "disable_external_urls": {
+          "name": "disable_external_urls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worlds": {
+      "name": "worlds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "worlds_author_id_users_id_fk": {
+          "name": "worlds_author_id_users_id_fk",
+          "tableFrom": "worlds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "worlds_name_unique": {
+          "name": "worlds_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.instance_access_type": {
+      "name": "instance_access_type",
+      "schema": "public",
+      "values": [
+        "public",
+        "friend_plus",
+        "friend_only",
+        "invite_only"
+      ]
+    },
+    "public.instance_status": {
+      "name": "instance_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "full",
+        "closing"
+      ]
+    },
+    "public.friend_status": {
+      "name": "friend_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1772529395128,
+      "tag": "0000_init_schema",
+      "breakpoints": true
+    }
+  ]
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,40 @@
+{
+    "name": "@ubichill/db",
+    "version": "1.0.0",
+    "private": true,
+    "description": "Database definitions and migrations for Ubichill",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.ts",
+            "import": "./dist/index.js",
+            "require": "./dist/index.js"
+        }
+    },
+    "scripts": {
+        "dev": "docker compose up -d && drizzle-kit studio",
+        "build": "tsc",
+        "clean": "rimraf dist",
+        "lint": "biome check .",
+        "lint:fix": "biome check --write .",
+        "generate": "drizzle-kit generate",
+        "push": "drizzle-kit push",
+        "stop": "docker compose down"
+    },
+    "dependencies": {
+        "@ubichill/shared": "workspace:*",
+        "drizzle-orm": "^0.45.1",
+        "drizzle-zod": "^0.8.3",
+        "nanoid": "^5.1.6",
+        "postgres": "^3.4.8",
+        "zod": "^4.3.6"
+    },
+    "devDependencies": {
+        "@types/node": "^22.13.4",
+        "drizzle-kit": "^0.31.9",
+        "rimraf": "^6.0.1",
+        "tsx": "^4.21.0",
+        "typescript": "^5.9.3"
+    }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,12 @@
+import { drizzle } from 'drizzle-orm/postgres-js';
+import postgres from 'postgres';
+import * as schema from './schema';
+
+const connectionString = process.env.DATABASE_URL || 'postgresql://ubichill:password@127.0.0.1:5433/ubichill';
+
+// Disable prefetch as it is not supported for "Transaction" pool mode
+export const client = postgres(connectionString, { prepare: false });
+export const db = drizzle(client, { schema });
+
+export * from './repositories';
+export * from './schema';

--- a/packages/db/src/repositories/index.ts
+++ b/packages/db/src/repositories/index.ts
@@ -1,0 +1,3 @@
+export * from './instanceRepository';
+export * from './userRepository';
+export * from './worldRepository';

--- a/packages/db/src/repositories/instanceRepository.ts
+++ b/packages/db/src/repositories/instanceRepository.ts
@@ -1,0 +1,117 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { db } from '../index';
+import { instances } from '../schema';
+
+export type InstanceRecord = typeof instances.$inferSelect;
+
+export interface CreateInstanceInput {
+    id?: string;
+    worldId: string;
+    leaderId: string;
+    accessType?: 'public' | 'friend_plus' | 'friend_only' | 'invite_only';
+    accessTags?: string[];
+    hasPassword?: boolean;
+    maxUsers?: number;
+    passwordHash?: string;
+}
+
+export interface UpdateInstanceInput {
+    status?: 'active' | 'full' | 'closing';
+    currentUsers?: number;
+    expiresAt?: Date | null;
+}
+
+export const instanceRepository = {
+    async findById(id: string): Promise<InstanceRecord | undefined> {
+        const results = await db.select().from(instances).where(eq(instances.id, id));
+        return results[0];
+    },
+
+    async findByWorldId(worldId: string): Promise<InstanceRecord[]> {
+        return db.select().from(instances).where(eq(instances.worldId, worldId));
+    },
+
+    async findByLeaderId(leaderId: string): Promise<InstanceRecord[]> {
+        return db.select().from(instances).where(eq(instances.leaderId, leaderId));
+    },
+
+    async findAll(options?: { includeFull?: boolean; tag?: string }): Promise<InstanceRecord[]> {
+        let query = db.select().from(instances);
+
+        if (!options?.includeFull) {
+            // 満員でないインスタンスのみを返す（activeまたはclosing）
+            query = query.where(eq(instances.status, 'active')) as typeof query;
+        }
+
+        const results = await query;
+
+        // タグフィルタリングはメモリ上で行う（jsonbフィールドのため）
+        if (options?.tag) {
+            const tag = options.tag;
+            return results.filter((i) => i.accessTags?.includes(tag));
+        }
+
+        return results;
+    },
+
+    async create(input: CreateInstanceInput): Promise<InstanceRecord> {
+        const results = await db
+            .insert(instances)
+            .values({
+                id: input.id,
+                worldId: input.worldId,
+                leaderId: input.leaderId,
+                accessType: input.accessType ?? 'public',
+                accessTags: input.accessTags ?? [],
+                hasPassword: input.hasPassword ?? false,
+                maxUsers: input.maxUsers ?? 10,
+                currentUsers: 0,
+                passwordHash: input.passwordHash,
+            })
+            .returning();
+        return results[0];
+    },
+
+    async update(id: string, input: UpdateInstanceInput): Promise<InstanceRecord | undefined> {
+        const results = await db
+            .update(instances)
+            .set({
+                ...input,
+            })
+            .where(eq(instances.id, id))
+            .returning();
+        return results[0];
+    },
+
+    async updateUserCount(id: string, delta: number): Promise<InstanceRecord | undefined> {
+        // 原子的に更新（greatest で 0 未満にならないようにする）
+        const results = await db
+            .update(instances)
+            .set({
+                currentUsers: sql`greatest(0, ${instances.currentUsers} + ${delta})`,
+                status: sql`
+                    case
+                        when greatest(0, ${instances.currentUsers} + ${delta}) >= ${instances.maxUsers} then 'full'::instance_status
+                        when greatest(0, ${instances.currentUsers} + ${delta}) = 0 then 'closing'::instance_status
+                        else 'active'::instance_status
+                    end
+                `,
+            })
+            .where(eq(instances.id, id))
+            .returning();
+        return results[0];
+    },
+
+    async delete(id: string): Promise<boolean> {
+        const result = await db.delete(instances).where(eq(instances.id, id)).returning();
+        return result.length > 0;
+    },
+
+    async deleteByLeader(id: string, leaderId: string): Promise<boolean> {
+        const result = await db
+            .delete(instances)
+            .where(and(eq(instances.id, id), eq(instances.leaderId, leaderId)))
+            .returning();
+        return result.length > 0;
+    },
+};

--- a/packages/db/src/repositories/userRepository.ts
+++ b/packages/db/src/repositories/userRepository.ts
@@ -1,0 +1,57 @@
+import { eq } from 'drizzle-orm';
+import { db } from '../index';
+import { users } from '../schema';
+
+export type UserRecord = typeof users.$inferSelect;
+
+export interface CreateUserInput {
+    id: string;
+    name: string;
+    email: string;
+    emailVerified?: boolean;
+    image?: string;
+    username?: string;
+    profileImageUrl?: string;
+}
+
+export const userRepository = {
+    async findById(id: string): Promise<UserRecord | undefined> {
+        const results = await db.select().from(users).where(eq(users.id, id));
+        return results[0];
+    },
+
+    async findByEmail(email: string): Promise<UserRecord | undefined> {
+        const results = await db.select().from(users).where(eq(users.email, email));
+        return results[0];
+    },
+
+    async create(input: CreateUserInput): Promise<UserRecord> {
+        const results = await db
+            .insert(users)
+            .values({
+                id: input.id,
+                name: input.name,
+                email: input.email,
+                emailVerified: input.emailVerified ?? false,
+                image: input.image,
+                username: input.username,
+                profileImageUrl: input.profileImageUrl,
+            })
+            .returning();
+        return results[0];
+    },
+
+    async ensureSystemUser(systemUserId: string): Promise<UserRecord> {
+        const existing = await this.findById(systemUserId);
+        if (existing) {
+            return existing;
+        }
+
+        return this.create({
+            id: systemUserId,
+            name: 'System',
+            email: 'system@ubichill.local',
+            emailVerified: true,
+        });
+    },
+};

--- a/packages/db/src/repositories/worldRepository.ts
+++ b/packages/db/src/repositories/worldRepository.ts
@@ -1,0 +1,114 @@
+import type { WorldDefinition } from '@ubichill/shared';
+import { eq } from 'drizzle-orm';
+import { db } from '../index';
+import { worlds } from '../schema';
+
+export interface CreateWorldInput {
+    authorId: string;
+    name: string;
+    version: string;
+    definition: WorldDefinition;
+}
+
+export interface UpdateWorldInput {
+    name?: string;
+    version?: string;
+    definition?: WorldDefinition;
+}
+
+export type WorldRecord = typeof worlds.$inferSelect;
+export type InsertWorldRecord = typeof worlds.$inferInsert;
+
+/**
+ * ワールドリポジトリ
+ * DBへのワールドCRUD操作を提供
+ */
+export const worldRepository = {
+    /**
+     * すべてのワールドを取得
+     */
+    async findAll(): Promise<WorldRecord[]> {
+        return db.select().from(worlds);
+    },
+
+    /**
+     * IDでワールドを取得
+     */
+    async findById(id: string): Promise<WorldRecord | undefined> {
+        const results = await db.select().from(worlds).where(eq(worlds.id, id));
+        return results[0];
+    },
+
+    /**
+     * 名前でワールドを取得
+     */
+    async findByName(name: string): Promise<WorldRecord | undefined> {
+        const results = await db.select().from(worlds).where(eq(worlds.name, name));
+        return results[0];
+    },
+
+    /**
+     * 作成者IDでワールドを取得
+     */
+    async findByAuthorId(authorId: string): Promise<WorldRecord[]> {
+        return db.select().from(worlds).where(eq(worlds.authorId, authorId));
+    },
+
+    /**
+     * ワールドを作成
+     */
+    async create(input: CreateWorldInput): Promise<WorldRecord> {
+        const results = await db
+            .insert(worlds)
+            .values({
+                authorId: input.authorId,
+                name: input.name,
+                version: input.version,
+                definition: input.definition,
+            })
+            .returning();
+        return results[0];
+    },
+
+    /**
+     * ワールドを更新
+     */
+    async update(id: string, input: UpdateWorldInput): Promise<WorldRecord | undefined> {
+        const results = await db
+            .update(worlds)
+            .set({
+                ...input,
+                updatedAt: new Date(),
+            })
+            .where(eq(worlds.id, id))
+            .returning();
+        return results[0];
+    },
+
+    /**
+     * ワールドを削除
+     */
+    async delete(id: string): Promise<boolean> {
+        const results = await db.delete(worlds).where(eq(worlds.id, id)).returning();
+        return results.length > 0;
+    },
+
+    /**
+     * 名前でワールドを upsert（存在すれば更新、なければ作成）
+     */
+    async upsertByName(input: CreateWorldInput): Promise<WorldRecord> {
+        const existing = await this.findByName(input.name);
+        if (existing) {
+            const updated = await this.update(existing.id, {
+                version: input.version,
+                definition: input.definition,
+            });
+            // updateは既存レコードを更新するので、必ずWorldRecordが返る
+            if (!updated) {
+                throw new Error(`Failed to update world: ${input.name}`);
+            }
+            return updated;
+        }
+        return this.create(input);
+    },
+};

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,0 +1,34 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+export * from './instances';
+export * from './users';
+export * from './worlds';
+
+// Import from schemas
+import { instances } from './instances';
+import { userFavorites, userFriends, userSettings, users } from './users';
+import { worlds } from './worlds';
+
+// users
+export const insertUserSchema = createInsertSchema(users);
+export const selectUserSchema = createSelectSchema(users);
+
+// user_settings
+export const insertUserSettingsSchema = createInsertSchema(userSettings);
+export const selectUserSettingsSchema = createSelectSchema(userSettings);
+
+// user_friends
+export const insertUserFriendSchema = createInsertSchema(userFriends);
+export const selectUserFriendSchema = createSelectSchema(userFriends);
+
+// user_favorites
+export const insertUserFavoriteSchema = createInsertSchema(userFavorites);
+export const selectUserFavoriteSchema = createSelectSchema(userFavorites);
+
+// worlds
+export const insertWorldSchema = createInsertSchema(worlds);
+export const selectWorldSchema = createSelectSchema(worlds);
+
+// instances
+export const insertInstanceSchema = createInsertSchema(instances);
+export const selectInstanceSchema = createSelectSchema(instances);

--- a/packages/db/src/schema/instances.ts
+++ b/packages/db/src/schema/instances.ts
@@ -1,0 +1,46 @@
+import { relations } from 'drizzle-orm';
+import { boolean, integer, jsonb, pgEnum, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { nanoid } from 'nanoid';
+import { users } from './users';
+import { worlds } from './worlds';
+
+export const instanceStatusEnum = pgEnum('instance_status', ['active', 'full', 'closing']);
+export const instanceAccessTypeEnum = pgEnum('instance_access_type', [
+    'public',
+    'friend_plus',
+    'friend_only',
+    'invite_only',
+]);
+
+export const instances = pgTable('instances', {
+    id: varchar('id', { length: 21 })
+        .$defaultFn(() => nanoid())
+        .primaryKey(),
+    worldId: varchar('world_id', { length: 21 })
+        .notNull()
+        .references(() => worlds.id, { onDelete: 'cascade' }),
+    leaderId: text('leader_id')
+        .notNull()
+        .references(() => users.id, { onDelete: 'cascade' }),
+    status: instanceStatusEnum('status').notNull().default('active'),
+    accessType: instanceAccessTypeEnum('access_type').notNull().default('public'),
+    accessTags: jsonb('access_tags').$type<string[]>().default([]),
+    hasPassword: boolean('has_password').notNull().default(false),
+    maxUsers: integer('max_users').notNull().default(10),
+    currentUsers: integer('current_users').notNull().default(0),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    expiresAt: timestamp('expires_at'),
+    // パスワード保護用（ハッシュ化して保存）
+    passwordHash: varchar('password_hash', { length: 255 }),
+});
+
+export const instancesRelations = relations(instances, ({ one }) => ({
+    world: one(worlds, {
+        fields: [instances.worldId],
+        references: [worlds.id],
+    }),
+    leader: one(users, {
+        fields: [instances.leaderId],
+        references: [users.id],
+    }),
+}));

--- a/packages/db/src/schema/users.ts
+++ b/packages/db/src/schema/users.ts
@@ -1,0 +1,141 @@
+import { relations } from 'drizzle-orm';
+import { boolean, pgEnum, pgTable, primaryKey, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { worlds } from './worlds';
+
+export const friendStatusEnum = pgEnum('friend_status', ['pending', 'accepted']);
+
+// Better Auth統合ユーザーテーブル
+// Better Authが必要とするフィールド + アプリ独自のフィールド
+export const users = pgTable('users', {
+    // Better Auth required fields (text型、UUIDではなくnanoid)
+    id: text('id').primaryKey(),
+    name: text('name').notNull(),
+    email: text('email').notNull().unique(),
+    emailVerified: boolean('email_verified').notNull().default(false),
+    image: text('image'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    // App-specific fields
+    username: varchar('username', { length: 255 }).unique(),
+    profileImageUrl: varchar('profile_image_url', { length: 1024 }),
+});
+
+// Better Auth session table
+export const sessions = pgTable('sessions', {
+    id: text('id').primaryKey(),
+    expiresAt: timestamp('expires_at').notNull(),
+    token: text('token').notNull().unique(),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    ipAddress: text('ip_address'),
+    userAgent: text('user_agent'),
+    userId: text('user_id')
+        .notNull()
+        .references(() => users.id, { onDelete: 'cascade' }),
+});
+
+// Better Auth account table (for password/oauth)
+export const accounts = pgTable('accounts', {
+    id: text('id').primaryKey(),
+    accountId: text('account_id').notNull(),
+    providerId: text('provider_id').notNull(),
+    userId: text('user_id')
+        .notNull()
+        .references(() => users.id, { onDelete: 'cascade' }),
+    accessToken: text('access_token'),
+    refreshToken: text('refresh_token'),
+    idToken: text('id_token'),
+    accessTokenExpiresAt: timestamp('access_token_expires_at'),
+    refreshTokenExpiresAt: timestamp('refresh_token_expires_at'),
+    scope: text('scope'),
+    password: text('password'),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+});
+
+// Better Auth verification table (for email verification)
+export const verifications = pgTable('verifications', {
+    id: text('id').primaryKey(),
+    identifier: text('identifier').notNull(),
+    value: text('value').notNull(),
+    expiresAt: timestamp('expires_at').notNull(),
+    createdAt: timestamp('created_at').defaultNow(),
+    updatedAt: timestamp('updated_at').defaultNow(),
+});
+
+export const userSettings = pgTable('user_settings', {
+    userId: text('user_id')
+        .primaryKey()
+        .references(() => users.id, { onDelete: 'cascade' }),
+    disableExternalUrls: boolean('disable_external_urls').default(false).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const userFriends = pgTable(
+    'user_friends',
+    {
+        userId: text('user_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade' }),
+        friendId: text('friend_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade' }),
+        status: friendStatusEnum('status').default('pending').notNull(),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.userId, table.friendId] })],
+);
+
+export const userFavorites = pgTable(
+    'user_favorites',
+    {
+        userId: text('user_id')
+            .notNull()
+            .references(() => users.id, { onDelete: 'cascade' }),
+        worldId: varchar('world_id', { length: 21 })
+            .notNull()
+            .references(() => worlds.id, { onDelete: 'cascade' }),
+        createdAt: timestamp('created_at').defaultNow().notNull(),
+    },
+    (table) => [primaryKey({ columns: [table.userId, table.worldId] })],
+);
+
+export const usersRelations = relations(users, ({ one, many }) => ({
+    settings: one(userSettings),
+    friends: many(userFriends, { relationName: 'userFriends' }),
+    friendsOf: many(userFriends, { relationName: 'friendUsers' }),
+    favorites: many(userFavorites),
+    worlds: many(worlds),
+}));
+
+export const userSettingsRelations = relations(userSettings, ({ one }) => ({
+    user: one(users, {
+        fields: [userSettings.userId],
+        references: [users.id],
+    }),
+}));
+
+export const userFriendsRelations = relations(userFriends, ({ one }) => ({
+    user: one(users, {
+        fields: [userFriends.userId],
+        references: [users.id],
+        relationName: 'userFriends',
+    }),
+    friend: one(users, {
+        fields: [userFriends.friendId],
+        references: [users.id],
+        relationName: 'friendUsers',
+    }),
+}));
+
+export const userFavoritesRelations = relations(userFavorites, ({ one }) => ({
+    user: one(users, {
+        fields: [userFavorites.userId],
+        references: [users.id],
+    }),
+    world: one(worlds, {
+        fields: [userFavorites.worldId],
+        references: [worlds.id],
+    }),
+}));

--- a/packages/db/src/schema/worlds.ts
+++ b/packages/db/src/schema/worlds.ts
@@ -1,0 +1,27 @@
+import type { WorldDefinition } from '@ubichill/shared';
+import { relations } from 'drizzle-orm';
+import { jsonb, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
+import { nanoid } from 'nanoid';
+import { userFavorites, users } from './users';
+
+export const worlds = pgTable('worlds', {
+    id: varchar('id', { length: 21 })
+        .$defaultFn(() => nanoid())
+        .primaryKey(),
+    authorId: text('author_id')
+        .notNull()
+        .references(() => users.id, { onDelete: 'cascade' }),
+    name: varchar('name', { length: 255 }).notNull().unique(),
+    version: varchar('version', { length: 50 }).notNull(),
+    definition: jsonb('definition').$type<WorldDefinition>().notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+    updatedAt: timestamp('updated_at').defaultNow().notNull(),
+});
+
+export const worldsRelations = relations(worlds, ({ one, many }) => ({
+    author: one(users, {
+        fields: [worlds.authorId],
+        references: [users.id],
+    }),
+    favoritedBy: many(userFavorites),
+}));

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "compilerOptions": {
+        "target": "ES2022",
+        "module": "CommonJS",
+        "moduleResolution": "node",
+        "declaration": true,
+        "sourceMap": true,
+        "outDir": "./dist",
+        "rootDir": "./src",
+        "strict": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "forceConsistentCasingInFileNames": true
+    },
+    "include": [
+        "src/**/*"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -19,6 +19,7 @@
         "@ubichill/plugin-video-player": "workspace:*",
         "@ubichill/sdk": "workspace:*",
         "@ubichill/shared": "workspace:*",
+        "better-auth": "^1.4.19",
         "icojs": "^0.20.1",
         "lodash.throttle": "^4.1.1",
         "next": "^16.1.6",

--- a/packages/frontend/panda.config.ts
+++ b/packages/frontend/panda.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
                     border: { value: '#e5e7eb' },
                 },
                 fonts: {
-                    body: { value: 'system-ui, sans-serif' },
+                    body: { value: 'var(--font-inter), system-ui, sans-serif' },
                     mono: { value: 'Menlo, monospace' },
                 },
             },

--- a/packages/frontend/src/app/auth/page.tsx
+++ b/packages/frontend/src/app/auth/page.tsx
@@ -1,0 +1,578 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useState } from 'react';
+import { API_BASE, registerWithOTP, resendOTP, signIn, useSession, verifyOTPAndRegister } from '@/lib/auth-client';
+import { css } from '@/styled-system/css';
+import { flex, vstack } from '@/styled-system/patterns';
+
+type AuthMode = 'login' | 'register' | 'verify';
+
+export default function AuthPage() {
+    const router = useRouter();
+    const { data: session, isPending } = useSession();
+    const [mode, setMode] = useState<AuthMode>('login');
+    const [email, setEmail] = useState('');
+    const [password, setPassword] = useState('');
+    const [username, setUsername] = useState('');
+    const [error, setError] = useState('');
+    const [success, setSuccess] = useState('');
+    const [isLoading, setIsLoading] = useState(false);
+    const [resendCooldown, setResendCooldown] = useState(0);
+    const [otp, setOtp] = useState('');
+    const [usernameError, setUsernameError] = useState('');
+    const [isCheckingUsername, setIsCheckingUsername] = useState(false);
+
+    // クールダウンタイマー
+    useEffect(() => {
+        if (resendCooldown > 0) {
+            const timer = setTimeout(() => setResendCooldown(resendCooldown - 1), 1000);
+            return () => clearTimeout(timer);
+        }
+    }, [resendCooldown]);
+
+    // Redirect if already logged in
+    useEffect(() => {
+        if (session && !isPending) {
+            router.push('/');
+        }
+    }, [session, isPending, router]);
+
+    // ユーザー名の重複チェック（デバウンス付き）
+    useEffect(() => {
+        const trimmedUsername = username.trim();
+        if (!trimmedUsername || mode !== 'register') {
+            setUsernameError('');
+            return;
+        }
+
+        // 長さチェック（1-30文字）
+        if (trimmedUsername.length < 1 || trimmedUsername.length > 30) {
+            setUsernameError('ユーザー名は1〜30文字で入力してください');
+            return;
+        }
+
+        let ignore = false;
+        const timer = setTimeout(async () => {
+            setIsCheckingUsername(true);
+            try {
+                const res = await fetch(
+                    `${API_BASE}/api/v1/users/check-username?username=${encodeURIComponent(trimmedUsername)}`,
+                );
+                const data = await res.json();
+
+                if (!ignore) {
+                    if (!data.available) {
+                        setUsernameError(data.error || 'このユーザー名は使用できません');
+                    } else {
+                        setUsernameError('');
+                    }
+                }
+            } catch {
+                if (!ignore) setUsernameError('確認に失敗しました');
+            } finally {
+                if (!ignore) setIsCheckingUsername(false);
+            }
+        }, 500);
+
+        return () => {
+            ignore = true;
+            clearTimeout(timer);
+        };
+    }, [username, mode]);
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+        setError('');
+        setSuccess('');
+        setIsLoading(true);
+
+        try {
+            if (mode === 'register') {
+                // ユーザー名のエラーがある場合は登録しない
+                if (usernameError) {
+                    setError(usernameError);
+                    setIsLoading(false);
+                    return;
+                }
+
+                // 仮登録（OTP送信）
+                const result = await registerWithOTP(email, password, username.trim());
+
+                if (!result.success) {
+                    setError(result.error || '登録に失敗しました');
+                } else if (result.skipVerification) {
+                    // メール確認をスキップした場合は直接ログインへ
+                    setSuccess(result.message || '登録が完了しました。ログインしてください。');
+                    // 1.5秒後にログイン画面に遷移
+                    setTimeout(() => {
+                        setMode('login');
+                        setPassword(''); // セキュリティのためパスワードをクリア
+                    }, 1500);
+                } else {
+                    // OTP入力画面へ遷移
+                    setMode('verify');
+                    setSuccess(result.message || '認証コードをメールに送信しました。');
+                    setResendCooldown(60);
+                }
+            } else {
+                // ログイン
+                const result = await signIn.email({
+                    email,
+                    password,
+                });
+
+                if (result.error) {
+                    setError(result.error.message || 'ログインに失敗しました');
+                } else {
+                    router.push('/');
+                }
+            }
+        } catch {
+            setError('エラーが発生しました。もう一度お試しください。');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const handleResendOTP = useCallback(async () => {
+        if (resendCooldown > 0 || !email) return;
+
+        setError('');
+        setSuccess('');
+        setIsLoading(true);
+
+        try {
+            const result = await resendOTP(email);
+            if (!result.success) {
+                setError(result.error || '認証コードの送信に失敗しました');
+            } else {
+                setSuccess('認証コードを再送信しました。メールをご確認ください。');
+                setResendCooldown(60);
+            }
+        } catch {
+            setError('認証コードの送信に失敗しました。');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [email, resendCooldown]);
+
+    const handleVerifyOTP = useCallback(async () => {
+        if (!email || !otp) return;
+
+        setError('');
+        setSuccess('');
+        setIsLoading(true);
+
+        try {
+            const result = await verifyOTPAndRegister(email, otp);
+            if (!result.success) {
+                setError(result.error || '認証コードが正しくありません');
+            } else {
+                setSuccess('登録が完了しました！ログインしてください。');
+                // 確認完了後、ログイン画面に戻る
+                setTimeout(() => {
+                    setMode('login');
+                    setOtp('');
+                    setUsername('');
+                    setPassword('');
+                }, 1500);
+            }
+        } catch {
+            setError('認証に失敗しました。');
+        } finally {
+            setIsLoading(false);
+        }
+    }, [email, otp]);
+
+    // ローディング中または既にログイン済みの場合
+    if (isPending || (session && !isPending)) {
+        return (
+            <main className={containerStyle}>
+                <div className={cardStyle}>
+                    <p>読み込み中...</p>
+                </div>
+            </main>
+        );
+    }
+
+    const handleBackToRegister = () => {
+        setMode('register');
+        setOtp('');
+        setError('');
+        setSuccess('');
+    };
+
+    // OTP入力画面
+    if (mode === 'verify') {
+        return (
+            <main className={containerStyle}>
+                <div className={cardStyle}>
+                    <h1 className={titleStyle}>認証コードを入力</h1>
+                    <p className={subtitleStyle}>{email} に6桁の認証コードを送信しました。</p>
+
+                    <form
+                        onSubmit={(e) => {
+                            e.preventDefault();
+                            handleVerifyOTP();
+                        }}
+                        className={formStyle}
+                    >
+                        <div className={fieldStyle}>
+                            <label htmlFor="otp" className={labelStyle}>
+                                認証コード
+                            </label>
+                            <input
+                                id="otp"
+                                type="text"
+                                value={otp}
+                                onChange={(e) => setOtp(e.target.value.replace(/\D/g, '').slice(0, 6))}
+                                placeholder="000000"
+                                className={otpInputStyle}
+                                maxLength={6}
+                                autoComplete="one-time-code"
+                            />
+                        </div>
+
+                        {error && <p className={errorStyle}>{error}</p>}
+                        {success && <p className={successStyle}>{success}</p>}
+
+                        <button type="submit" className={buttonStyle} disabled={isLoading || otp.length !== 6}>
+                            {isLoading ? '確認中...' : '確認する'}
+                        </button>
+                    </form>
+
+                    <div className={verifyInfoStyle}>
+                        <p>コードが届かない場合:</p>
+                        <ul className={verifyListStyle}>
+                            <li>迷惑メールフォルダをご確認ください</li>
+                            <li>コードは10分間有効です</li>
+                        </ul>
+                    </div>
+
+                    <button
+                        type="button"
+                        className={linkButtonStyle}
+                        onClick={handleResendOTP}
+                        disabled={isLoading || resendCooldown > 0}
+                    >
+                        {resendCooldown > 0 ? `再送信まで ${resendCooldown}秒` : '認証コードを再送信'}
+                    </button>
+
+                    <button type="button" className={linkButtonStyle} onClick={handleBackToRegister}>
+                        登録画面に戻る
+                    </button>
+                </div>
+            </main>
+        );
+    }
+
+    return (
+        <main className={containerStyle}>
+            <div className={cardStyle}>
+                <h1 className={titleStyle}>Ubichill</h1>
+                <p className={subtitleStyle}>2Dメタバーススタイルのコラボレーションスペース</p>
+
+                <div className={tabContainerStyle}>
+                    <button
+                        type="button"
+                        className={mode === 'login' ? tabActiveStyle : tabStyle}
+                        onClick={() => setMode('login')}
+                    >
+                        ログイン
+                    </button>
+                    <button
+                        type="button"
+                        className={mode === 'register' ? tabActiveStyle : tabStyle}
+                        onClick={() => setMode('register')}
+                    >
+                        新規登録
+                    </button>
+                </div>
+
+                <form onSubmit={handleSubmit} className={formStyle}>
+                    {mode === 'register' && (
+                        <div className={fieldStyle}>
+                            <label htmlFor="username" className={labelStyle}>
+                                ユーザー名
+                            </label>
+                            <input
+                                id="username"
+                                type="text"
+                                value={username}
+                                onChange={(e) => setUsername(e.target.value.slice(0, 30))}
+                                placeholder="ユーザー名"
+                                className={usernameError ? inputErrorStyle : inputStyle}
+                                required
+                            />
+                            {isCheckingUsername && <p className={hintStyle}>確認中...</p>}
+                            {usernameError && <p className={fieldErrorStyle}>{usernameError}</p>}
+                            {!usernameError && username.trim().length >= 1 && !isCheckingUsername && (
+                                <p className={fieldSuccessStyle}>このユーザー名は使用できます</p>
+                            )}
+                            <p className={hintStyle}>1〜30文字で自由に設定できます</p>
+                        </div>
+                    )}
+
+                    <div className={fieldStyle}>
+                        <label htmlFor="email" className={labelStyle}>
+                            メールアドレス
+                        </label>
+                        <input
+                            id="email"
+                            type="email"
+                            value={email}
+                            onChange={(e) => setEmail(e.target.value)}
+                            placeholder="example@email.com"
+                            className={inputStyle}
+                            required
+                        />
+                    </div>
+
+                    <div className={fieldStyle}>
+                        <label htmlFor="password" className={labelStyle}>
+                            パスワード
+                        </label>
+                        <input
+                            id="password"
+                            type="password"
+                            value={password}
+                            onChange={(e) => setPassword(e.target.value)}
+                            placeholder="8文字以上"
+                            className={inputStyle}
+                            minLength={8}
+                            required
+                        />
+                    </div>
+
+                    {error && <p className={errorStyle}>{error}</p>}
+                    {success && <p className={successStyle}>{success}</p>}
+
+                    <button
+                        type="submit"
+                        className={buttonStyle}
+                        disabled={isLoading || (mode === 'register' && isCheckingUsername)}
+                    >
+                        {isLoading ? '処理中...' : mode === 'login' ? 'ログイン' : '登録'}
+                    </button>
+                </form>
+            </div>
+        </main>
+    );
+}
+
+// Styles
+const containerStyle = flex({
+    minH: 'screen',
+    alignItems: 'center',
+    justifyContent: 'center',
+    bg: 'gray.50',
+    _dark: { bg: 'gray.900' },
+});
+
+const cardStyle = vstack({
+    gap: '6',
+    p: '8',
+    bg: 'white',
+    rounded: 'xl',
+    shadow: 'lg',
+    w: 'full',
+    maxW: '400px',
+    _dark: { bg: 'gray.800' },
+});
+
+const titleStyle = css({
+    fontSize: '3xl',
+    fontWeight: 'bold',
+    color: 'gray.800',
+    _dark: { color: 'white' },
+});
+
+const subtitleStyle = css({
+    fontSize: 'sm',
+    color: 'gray.500',
+    textAlign: 'center',
+});
+
+const tabContainerStyle = flex({
+    w: 'full',
+    gap: '2',
+    bg: 'gray.100',
+    p: '1',
+    rounded: 'lg',
+    _dark: { bg: 'gray.700' },
+});
+
+const tabStyle = css({
+    flex: 1,
+    py: '2',
+    px: '4',
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'gray.600',
+    rounded: 'md',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    _hover: { color: 'gray.800' },
+    _dark: { color: 'gray.400', _hover: { color: 'white' } },
+});
+
+const tabActiveStyle = css({
+    flex: 1,
+    py: '2',
+    px: '4',
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'white',
+    bg: 'blue.500',
+    rounded: 'md',
+    cursor: 'pointer',
+});
+
+const formStyle = vstack({
+    gap: '4',
+    w: 'full',
+});
+
+const fieldStyle = vstack({
+    gap: '1',
+    w: 'full',
+    alignItems: 'flex-start',
+});
+
+const labelStyle = css({
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'gray.700',
+    _dark: { color: 'gray.300' },
+});
+
+const inputStyle = css({
+    w: 'full',
+    py: '2.5',
+    px: '3',
+    fontSize: 'sm',
+    borderWidth: '1px',
+    borderColor: 'gray.300',
+    rounded: 'lg',
+    outline: 'none',
+    transition: 'all 0.2s',
+    _focus: { borderColor: 'blue.500', ring: '2', ringColor: 'blue.500/20' },
+    _dark: { bg: 'gray.700', borderColor: 'gray.600', color: 'white' },
+});
+
+const inputErrorStyle = css({
+    w: 'full',
+    py: '2.5',
+    px: '3',
+    fontSize: 'sm',
+    borderWidth: '1px',
+    borderColor: 'red.500',
+    rounded: 'lg',
+    outline: 'none',
+    transition: 'all 0.2s',
+    _focus: { borderColor: 'red.500', ring: '2', ringColor: 'red.500/20' },
+    _dark: { bg: 'gray.700', borderColor: 'red.500', color: 'white' },
+});
+
+const fieldErrorStyle = css({
+    fontSize: 'xs',
+    color: 'red.500',
+});
+
+const fieldSuccessStyle = css({
+    fontSize: 'xs',
+    color: 'green.500',
+});
+
+const hintStyle = css({
+    fontSize: 'xs',
+    color: 'gray.400',
+});
+
+const otpInputStyle = css({
+    w: 'full',
+    py: '4',
+    px: '4',
+    fontSize: '2xl',
+    fontWeight: 'bold',
+    textAlign: 'center',
+    letterSpacing: '0.5em',
+    borderWidth: '2px',
+    borderColor: 'gray.300',
+    rounded: 'lg',
+    outline: 'none',
+    transition: 'all 0.2s',
+    _focus: { borderColor: 'blue.500', ring: '2', ringColor: 'blue.500/20' },
+    _dark: { bg: 'gray.700', borderColor: 'gray.600', color: 'white' },
+});
+
+const buttonStyle = css({
+    w: 'full',
+    py: '2.5',
+    px: '4',
+    fontSize: 'sm',
+    fontWeight: 'medium',
+    color: 'white',
+    bg: 'blue.500',
+    rounded: 'lg',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    _hover: { bg: 'blue.600' },
+    _disabled: { opacity: 0.6, cursor: 'not-allowed' },
+});
+
+const linkButtonStyle = css({
+    py: '2',
+    fontSize: 'sm',
+    color: 'gray.500',
+    bg: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'all 0.2s',
+    _hover: { color: 'blue.500' },
+});
+
+const errorStyle = css({
+    w: 'full',
+    py: '2',
+    px: '3',
+    fontSize: 'sm',
+    color: 'red.600',
+    bg: 'red.50',
+    rounded: 'lg',
+    _dark: { bg: 'red.900/20', color: 'red.400' },
+});
+
+const successStyle = css({
+    w: 'full',
+    py: '2',
+    px: '3',
+    fontSize: 'sm',
+    color: 'green.600',
+    bg: 'green.50',
+    rounded: 'lg',
+    _dark: { bg: 'green.900/20', color: 'green.400' },
+});
+
+const verifyInfoStyle = css({
+    w: 'full',
+    py: '4',
+    px: '4',
+    fontSize: 'sm',
+    color: 'gray.600',
+    bg: 'gray.50',
+    rounded: 'lg',
+    _dark: { bg: 'gray.700', color: 'gray.300' },
+});
+
+const verifyListStyle = css({
+    mt: '2',
+    ml: '4',
+    listStyleType: 'disc',
+    fontSize: 'xs',
+    color: 'gray.500',
+    '& li': {
+        mt: '1',
+    },
+});

--- a/packages/frontend/src/app/layout.tsx
+++ b/packages/frontend/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import { Providers } from './providers';
 
-const inter = Inter({ subsets: ['latin'] });
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter', display: 'swap' });
 
 export const metadata: Metadata = {
     title: 'Ubichill',
@@ -15,8 +15,8 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
-        <html lang="en">
-            <body className={inter.className}>
+        <html lang="ja" className={inter.variable}>
+            <body>
                 <Providers>{children}</Providers>
             </body>
         </html>

--- a/packages/frontend/src/app/world/[id]/page.tsx
+++ b/packages/frontend/src/app/world/[id]/page.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useSocket, useWorld } from '@ubichill/sdk';
+import { useParams, useRouter } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+import { UbichillOverlay } from '@/components/UbichillOverlay';
+import { useCursorState } from '@/core/hooks/useCursorState';
+import { useSession } from '@/lib/auth-client';
+import { css } from '@/styled-system/css';
+
+export default function WorldPage() {
+    const router = useRouter();
+    const params = useParams<{ id: string }>();
+    const { data: session, isPending } = useSession();
+
+    // Core SDK
+    const { isConnected, error, joinWorld, updatePosition } = useSocket();
+    const { environment } = useWorld();
+
+    // UI states
+    const [connecting, setConnecting] = useState(true);
+    const hasJoinedRef = useRef(false);
+    const cursorState = useCursorState();
+
+    // Ensure auth and connect (1度だけ実行)
+    useEffect(() => {
+        if (isPending) return;
+
+        if (!session) {
+            router.push('/auth');
+            return;
+        }
+
+        // 重複実行を防止
+        if (hasJoinedRef.current) return;
+
+        if (params.id) {
+            hasJoinedRef.current = true;
+            // "default" is a placeholder instance ID for simply joining the world's default instance space
+            joinWorld(session.user.name, params.id, 'default');
+            setConnecting(false);
+        }
+    }, [session, isPending, router, params.id, joinWorld]);
+
+    if (isPending || connecting) {
+        return (
+            <div className={css({ minH: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center' })}>
+                <p>接続中...</p>
+            </div>
+        );
+    }
+
+    if (error && !isConnected) {
+        return (
+            <div
+                className={css({
+                    minH: '100vh',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    flexDir: 'column',
+                    gap: 4,
+                })}
+            >
+                <p className={css({ color: 'red.500' })}>{error}</p>
+                <button
+                    type="button"
+                    onClick={() => router.push('/')}
+                    className={css({ padding: '8px 16px', bg: 'gray.200', rounded: 'md' })}
+                >
+                    戻る
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <main
+            style={{
+                width: '100vw',
+                height: '100vh',
+                position: 'relative',
+                overflow: 'hidden',
+                backgroundColor: environment?.backgroundColor || '#f8f9fa',
+                backgroundImage: environment?.backgroundImage ? `url(${environment.backgroundImage})` : 'none',
+                backgroundSize: 'cover',
+                backgroundPosition: 'center',
+            }}
+            onPointerMove={(e) => {
+                updatePosition({ x: e.clientX, y: e.clientY }, cursorState);
+            }}
+        >
+            <UbichillOverlay />
+        </main>
+    );
+}

--- a/packages/frontend/src/core/hooks/useInstances.ts
+++ b/packages/frontend/src/core/hooks/useInstances.ts
@@ -26,7 +26,9 @@ export function useInstances(): UseInstancesReturn {
     const refreshInstances = useCallback(async () => {
         setLoading(true);
         try {
-            const res = await fetch(`${API_BASE}/api/v1/instances`);
+            const res = await fetch(`${API_BASE}/api/v1/instances`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error('Failed to fetch instances');
             const data = await res.json();
             setInstances(data.instances);
@@ -40,7 +42,9 @@ export function useInstances(): UseInstancesReturn {
     const refreshWorlds = useCallback(async () => {
         setLoading(true);
         try {
-            const res = await fetch(`${API_BASE}/api/v1/worlds`);
+            const res = await fetch(`${API_BASE}/api/v1/worlds`, {
+                credentials: 'include',
+            });
             if (!res.ok) throw new Error('Failed to fetch worlds');
             const data = await res.json();
             setWorlds(data.worlds);
@@ -59,6 +63,7 @@ export function useInstances(): UseInstancesReturn {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(request),
+                credentials: 'include',
             });
             if (!res.ok) {
                 const data = await res.json();

--- a/packages/frontend/src/lib/auth-client.ts
+++ b/packages/frontend/src/lib/auth-client.ts
@@ -1,0 +1,78 @@
+import { createAuthClient } from 'better-auth/react';
+
+// ブラウザ(CSR)ではNEXT_PUBLIC_API_URLを使う（外部URL）
+// SSR(Podから別Podへ)ではBACKEND_INTERNAL_URLを使う（K8s内部Service DNS）
+// typeof window === 'undefined' はSSRを示す
+const API_BASE =
+    typeof window === 'undefined'
+        ? (process.env.BACKEND_INTERNAL_URL ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001')
+        : (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001');
+
+export { API_BASE };
+
+export const authClient = createAuthClient({
+    baseURL: API_BASE,
+});
+
+export const { signIn, signOut, useSession } = authClient;
+
+// カスタム登録フロー: 仮登録（OTP送信）
+export const registerWithOTP = async (
+    email: string,
+    password: string,
+    username: string,
+): Promise<{ success: boolean; error?: string; skipVerification?: boolean; message?: string }> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/users/register`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password, username }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+            return { success: false, error: data.error || '登録に失敗しました' };
+        }
+        return { success: true, skipVerification: data.skipVerification, message: data.message };
+    } catch {
+        return { success: false, error: '通信エラーが発生しました' };
+    }
+};
+
+// カスタム登録フロー: OTP検証して本登録
+export const verifyOTPAndRegister = async (
+    email: string,
+    otp: string,
+): Promise<{ success: boolean; error?: string }> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/users/verify`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, otp }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+            return { success: false, error: data.error || '認証に失敗しました' };
+        }
+        return { success: true };
+    } catch {
+        return { success: false, error: '通信エラーが発生しました' };
+    }
+};
+
+// OTP再送信
+export const resendOTP = async (email: string): Promise<{ success: boolean; error?: string }> => {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/users/resend-otp`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+            return { success: false, error: data.error || '再送信に失敗しました' };
+        }
+        return { success: true };
+    } catch {
+        return { success: false, error: '通信エラーが発生しました' };
+    }
+};

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -220,7 +220,7 @@ export interface ServerToClientEvents {
 export interface ClientToServerEvents {
     /** ワールドに参加 */
     'world:join': (
-        data: { worldId: string; instanceId?: string; user: Omit<User, 'id'> },
+        data: { worldId: string; instanceId?: string; password?: string; user: Omit<User, 'id'> },
         callback: (response: { success: boolean; userId?: string; error?: string }) => void,
     ) => void;
 
@@ -278,6 +278,13 @@ export interface SocketData {
     worldId?: string;
     instanceId?: string;
     user?: User;
+    /** better-auth で認証されたユーザー情報（接続時にセット、以降不変） */
+    authUser?: {
+        id: string;
+        email: string;
+        name: string;
+        image: string | null;
+    };
 }
 
 // ============================================

--- a/packages/shared/src/schemas/world.schema.ts
+++ b/packages/shared/src/schemas/world.schema.ts
@@ -160,7 +160,8 @@ export type InitialEntity = z.infer<typeof InitialEntitySchema>;
 // ============================================
 
 export const ResolvedWorldSchema = z.object({
-    id: z.string(),
+    id: z.string(), // 人間が読める識別子（name）
+    dbId: z.string(), // DBの実際のID（nanoid、外部キー用）
     version: z.string(),
     displayName: z.string(),
     description: z.string().optional(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,15 +35,27 @@ importers:
       '@distube/ytdl-core':
         specifier: ^4.16.12
         version: 4.16.12
+      '@ubichill/db':
+        specifier: workspace:*
+        version: link:../db
       '@ubichill/shared':
         specifier: workspace:*
         version: link:../shared
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
+      better-auth:
+        specifier: ^1.4.19
+        version: 1.4.19(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       cors:
         specifier: ^2.8.5
         version: 2.8.6
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8)
       express:
         specifier: ^5.2.1
         version: 5.2.1
@@ -53,6 +65,9 @@ importers:
       helmet:
         specifier: ^8.1.0
         version: 8.1.0
+      resend:
+        specifier: ^6.9.2
+        version: 6.9.2
       socket.io:
         specifier: ^4.8.3
         version: 4.8.3
@@ -63,6 +78,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/cors':
         specifier: ^2.8.17
         version: 2.8.19
@@ -84,12 +102,52 @@ importers:
       ts-node-dev:
         specifier: ^2.0.0
         version: 2.0.0(@types/node@22.19.7)(typescript@5.9.3)
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       wait-on:
         specifier: ^9.0.3
         version: 9.0.3
+
+  packages/db:
+    dependencies:
+      '@ubichill/shared':
+        specifier: workspace:*
+        version: link:../shared
+      drizzle-orm:
+        specifier: ^0.45.1
+        version: 0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8)
+      drizzle-zod:
+        specifier: ^0.8.3
+        version: 0.8.3(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8))(zod@4.3.6)
+      nanoid:
+        specifier: ^5.1.6
+        version: 5.1.6
+      postgres:
+        specifier: ^3.4.8
+        version: 3.4.8
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.13.4
+        version: 22.19.7
+      drizzle-kit:
+        specifier: ^0.31.9
+        version: 0.31.9
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.2
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/frontend:
     dependencies:
@@ -108,6 +166,9 @@ importers:
       '@ubichill/shared':
         specifier: workspace:*
         version: link:../shared
+      better-auth:
+        specifier: ^1.4.19
+        version: 1.4.19(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       icojs:
         specifier: ^0.20.1
         version: 0.20.1(@jimp/custom@0.22.12)
@@ -299,6 +360,27 @@ packages:
     resolution: {integrity: sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==}
     engines: {node: '>=6.9.0'}
 
+  '@better-auth/core@1.4.19':
+    resolution: {integrity: sha512-uADLHG1jc5BnEJi7f6ijUN5DmPPRSj++7m/G19z3UqA3MVCo4Y4t1MMa4IIxLCqGDFv22drdfxescgW+HnIowA==}
+    peerDependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      better-call: 1.1.8
+      jose: ^6.1.0
+      kysely: ^0.28.5
+      nanostores: ^1.0.1
+
+  '@better-auth/telemetry@1.4.19':
+    resolution: {integrity: sha512-ApGNS7olCTtDpKF8Ow3Z+jvFAirOj7c4RyFUpu8axklh3mH57ndpfUAUjhgA8UVoaaH/mnm/Tl884BlqiewLyw==}
+    peerDependencies:
+      '@better-auth/core': 1.4.19
+
+  '@better-auth/utils@0.3.0':
+    resolution: {integrity: sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==}
+
+  '@better-fetch/fetch@1.1.21':
+    resolution: {integrity: sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==}
+
   '@biomejs/biome@2.3.13':
     resolution: {integrity: sha512-Fw7UsV0UAtWIBIm0M7g5CRerpu1eKyKAXIazzxhbXYUyMkwNrkX/KLkGI7b+uVDQ5cLUMfOC9vR60q9IDYDstA==}
     engines: {node: '>=14.21.3'}
@@ -388,11 +470,22 @@ packages:
     resolution: {integrity: sha512-/NR8Jur1Q4E2oD+DJta7uwWu7SkqdEkhwERt7f4iune70zg7ZlLLTOHs1+jgg3uD2jQjpdk7RGC16FqstG4RsA==}
     engines: {node: '>=20.18.1'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
 
   '@epic-web/invariant@1.0.0':
     resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.is'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -400,10 +493,34 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -412,16 +529,52 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -430,10 +583,34 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -442,10 +619,34 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -454,10 +655,34 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -466,10 +691,34 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -478,10 +727,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.12':
@@ -490,8 +763,26 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.12':
     resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
@@ -502,8 +793,26 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
@@ -514,8 +823,26 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.12':
     resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
@@ -526,16 +853,52 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
     os: [win32]
 
   '@esbuild/win32-ia32@0.25.12':
@@ -544,8 +907,26 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -826,6 +1207,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@noble/ciphers@2.1.1':
+    resolution: {integrity: sha512-bysYuiVfhxNJuldNXlFEitTVdNnYUc+XNJZd7Qm2a5j1vZHgY+fazadNFWFaMK/2vye0JVlxV3gHmC0WDfAOQw==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.0.1':
+    resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
+    engines: {node: '>= 20.19.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -893,6 +1282,9 @@ packages:
   '@socket.io/component-emitter@3.1.2':
     resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -920,6 +1312,10 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -956,6 +1352,9 @@ packages:
 
   '@types/node@22.19.7':
     resolution: {integrity: sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==}
+
+  '@types/pg@8.16.0':
+    resolution: {integrity: sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==}
 
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
@@ -1082,6 +1481,80 @@ packages:
   baseline-browser-mapping@2.9.19:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
+    hasBin: true
+
+  better-auth@1.4.19:
+    resolution: {integrity: sha512-3RlZJcA0+NH25wYD85vpIGwW9oSTuEmLIaGbT8zg41w/Pa2hVWHKedjoUHHJtnzkBXzDb+CShkLnSw7IThDdqQ==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: '>=0.41.0'
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.1.8:
+    resolution: {integrity: sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1251,6 +1724,9 @@ packages:
     resolution: {integrity: sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA==}
     engines: {node: '>=8.6'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -1270,6 +1746,108 @@ packages:
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
     engines: {node: '>=12'}
+
+  drizzle-kit@0.31.9:
+    resolution: {integrity: sha512-GViD3IgsXn7trFyBUUHyTFBpH/FsHTxYJ66qdbVggxef4UBPHRYxQaRzYLTuekYnk9i5FIEL9pbBIwMqX/Uwrg==}
+    hasBin: true
+
+  drizzle-orm@0.45.1:
+    resolution: {integrity: sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
+  drizzle-zod@0.8.3:
+    resolution: {integrity: sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww==}
+    peerDependencies:
+      drizzle-orm: '>=0.36.0'
+      zod: ^3.25.0 || ^4.0.0
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1325,8 +1903,23 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  esbuild-register@3.6.0:
+    resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
+    peerDependencies:
+      esbuild: '>=0.12 <1'
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1391,6 +1984,9 @@ packages:
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
     engines: {node: '>=8.6.0'}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -1476,6 +2072,9 @@ packages:
 
   get-them-args@1.3.2:
     resolution: {integrity: sha512-LRn8Jlk+DwZE4GTlDbT3Hikd1wSHgLMme/+7ddlqKd7ldwR6LjJgTVWzBnR01wnYGe4KgrXjg287RaI22UHmAw==}
+
+  get-tsconfig@4.13.6:
+    resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1647,6 +2246,10 @@ packages:
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  kysely@0.28.11:
+    resolution: {integrity: sha512-zpGIFg0HuoC893rIjYX1BETkVWdDnzTzF5e0kWXJFg5lE0k1/LfNWBejrcnOFu8Q2Rfq/hTDTU7XLUM8QOrpzg==}
+    engines: {node: '>=20.0.0'}
 
   lightningcss-android-arm64@1.30.2:
     resolution: {integrity: sha512-BH9sEdOCahSgmkVhBLeU7Hc9DWeZ1Eb6wNS6Da8igvUwAe0sqROHddIlvU06q3WyXVEOYDZ6ykBZQnjTbmo4+A==}
@@ -1830,6 +2433,15 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.6:
+    resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  nanostores@1.1.0:
+    resolution: {integrity: sha512-yJBmDJr18xy47dbNVlHcgdPrulSn1nhSE6Ns9vTG+Nx9VPT6iV1MD6aQFp/t52zpf82FhLLTXAXr30NuCnxvwA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
+
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
@@ -1963,6 +2575,17 @@ packages:
   perfect-freehand@1.2.2:
     resolution: {integrity: sha512-eh31l019WICQ03pkF3FSzHxB8n07ItqIQ++G5UV8JX0zVOXzgTGCqnRR0jJ2h9U8/2uW4W4mtGJELt9kEV0CFQ==}
 
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-protocol@1.11.0:
+    resolution: {integrity: sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -1996,6 +2619,9 @@ packages:
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
+
+  postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
 
   postcss-discard-duplicates@7.0.2:
     resolution: {integrity: sha512-eTonaQvPZ/3i1ASDHOKkYwAybiM45zFIc7KXils4mQmHLqIswXD9XNOKEVxtTFnsmwYzF66u4LMgSr0abDlh5w==}
@@ -2047,6 +2673,26 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres@3.4.8:
+    resolution: {integrity: sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==}
+    engines: {node: '>=12'}
 
   prettier@3.2.5:
     resolution: {integrity: sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==}
@@ -2123,6 +2769,18 @@ packages:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
+  resend@6.9.2:
+    resolution: {integrity: sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
   resolve@1.22.11:
     resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
     engines: {node: '>= 0.4'}
@@ -2141,6 +2799,9 @@ packages:
     resolution: {integrity: sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==}
     engines: {node: 20 || >=22}
     hasBin: true
+
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
@@ -2177,6 +2838,9 @@ packages:
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -2256,6 +2920,9 @@ packages:
   split@0.3.3:
     resolution: {integrity: sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -2322,6 +2989,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  svix@1.84.1:
+    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -2446,6 +3116,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo-darwin-64@2.8.3:
     resolution: {integrity: sha512-4kXRLfcygLOeNcP6JquqRLmGB/ATjjfehiojL2dJkL7GFm3SPSXbq7oNj8UbD8XriYQ5hPaSuz59iF1ijPHkTw==}
     cpu: [x64]
@@ -2522,6 +3197,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -2628,6 +3307,27 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@better-auth/core@1.4.19(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)':
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.1.8(zod@4.3.6)
+      jose: 6.1.3
+      kysely: 0.28.11
+      nanostores: 1.1.0
+      zod: 4.3.6
+
+  '@better-auth/telemetry@1.4.19(@better-auth/core@1.4.19(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))':
+    dependencies:
+      '@better-auth/core': 1.4.19(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+
+  '@better-auth/utils@0.3.0': {}
+
+  '@better-fetch/fetch@1.1.21': {}
+
   '@biomejs/biome@2.3.13':
     optionalDependencies:
       '@biomejs/cli-darwin-arm64': 2.3.13
@@ -2704,6 +3404,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/runtime@1.8.1':
     dependencies:
       tslib: 2.8.1
@@ -2711,82 +3413,236 @@ snapshots:
 
   '@epic-web/invariant@1.0.0': {}
 
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.13.6
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.18.20':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.18.20':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.18.20':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.18.20':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.18.20':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.18.20':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.18.20':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.18.20':
     optional: true
 
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
   '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.18.20':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@hapi/address@5.1.1':
@@ -2998,6 +3854,10 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
+  '@noble/ciphers@2.1.1': {}
+
+  '@noble/hashes@2.0.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3203,6 +4063,8 @@ snapshots:
 
   '@socket.io/component-emitter@3.1.2': {}
 
+  '@stablelib/base64@1.0.1': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@swc/helpers@0.5.15':
@@ -3231,6 +4093,10 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -3277,6 +4143,13 @@ snapshots:
   '@types/node@22.19.7':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/pg@8.16.0':
+    dependencies:
+      '@types/node': 22.19.7
+      pg-protocol: 1.11.0
+      pg-types: 2.2.0
+    optional: true
 
   '@types/qs@6.14.0': {}
 
@@ -3406,6 +4279,38 @@ snapshots:
   base64id@2.0.0: {}
 
   baseline-browser-mapping@2.9.19: {}
+
+  bcryptjs@3.0.3: {}
+
+  better-auth@1.4.19(drizzle-kit@0.31.9)(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8))(next@16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@better-auth/core': 1.4.19(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0)
+      '@better-auth/telemetry': 1.4.19(@better-auth/core@1.4.19(@better-auth/utils@0.3.0)(@better-fetch/fetch@1.1.21)(better-call@1.1.8(zod@4.3.6))(jose@6.1.3)(kysely@0.28.11)(nanostores@1.1.0))
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      '@noble/ciphers': 2.1.1
+      '@noble/hashes': 2.0.1
+      better-call: 1.1.8(zod@4.3.6)
+      defu: 6.1.4
+      jose: 6.1.3
+      kysely: 0.28.11
+      nanostores: 1.1.0
+      zod: 4.3.6
+    optionalDependencies:
+      drizzle-kit: 0.31.9
+      drizzle-orm: 0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8)
+      next: 16.1.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  better-call@1.1.8(zod@4.3.6):
+    dependencies:
+      '@better-auth/utils': 0.3.0
+      '@better-fetch/fetch': 1.1.21
+      rou3: 0.7.12
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      zod: 4.3.6
 
   binary-extensions@2.3.0: {}
 
@@ -3591,6 +4496,8 @@ snapshots:
       decode-bmp: 0.2.1
       to-data-view: 1.1.0
 
+  defu@6.1.4: {}
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -3600,6 +4507,26 @@ snapshots:
   diff@4.0.4: {}
 
   dotenv@17.2.3: {}
+
+  drizzle-kit@0.31.9:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      esbuild-register: 3.6.0(esbuild@0.25.12)
+    transitivePeerDependencies:
+      - supports-color
+
+  drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8):
+    optionalDependencies:
+      '@types/pg': 8.16.0
+      kysely: 0.28.11
+      postgres: 3.4.8
+
+  drizzle-zod@0.8.3(drizzle-orm@0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8))(zod@4.3.6):
+    dependencies:
+      drizzle-orm: 0.45.1(@types/pg@8.16.0)(kysely@0.28.11)(postgres@3.4.8)
+      zod: 4.3.6
 
   dunder-proto@1.0.1:
     dependencies:
@@ -3668,6 +4595,38 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  esbuild-register@3.6.0(esbuild@0.25.12):
+    dependencies:
+      debug: 4.4.3(supports-color@5.5.0)
+      esbuild: 0.25.12
+    transitivePeerDependencies:
+      - supports-color
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -3696,6 +4655,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
 
   escalade@3.2.0: {}
 
@@ -3780,6 +4768,8 @@ snapshots:
       glob-parent: 5.1.2
       merge2: 1.4.1
       micromatch: 4.0.8
+
+  fast-sha256@1.3.0: {}
 
   fast-uri@3.1.0: {}
 
@@ -3871,6 +4861,10 @@ snapshots:
       es-object-atoms: 1.1.1
 
   get-them-args@1.3.2: {}
+
+  get-tsconfig@4.13.6:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
 
   glob-parent@5.1.2:
     dependencies:
@@ -4040,6 +5034,8 @@ snapshots:
 
   kleur@4.1.5: {}
 
+  kysely@0.28.11: {}
+
   lightningcss-android-arm64@1.30.2:
     optional: true
 
@@ -4165,6 +5161,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.6: {}
+
+  nanostores@1.1.0: {}
+
   negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
@@ -4275,6 +5275,21 @@ snapshots:
 
   perfect-freehand@1.2.2: {}
 
+  pg-int8@1.0.1:
+    optional: true
+
+  pg-protocol@1.11.0:
+    optional: true
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+    optional: true
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -4298,6 +5313,8 @@ snapshots:
   pngjs@3.4.0: {}
 
   pngjs@7.0.0: {}
+
+  postal-mime@2.7.3: {}
 
   postcss-discard-duplicates@7.0.2(postcss@8.5.6):
     dependencies:
@@ -4349,6 +5366,22 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  postgres-array@2.0.0:
+    optional: true
+
+  postgres-bytea@1.0.1:
+    optional: true
+
+  postgres-date@1.0.7:
+    optional: true
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+    optional: true
+
+  postgres@3.4.8: {}
 
   prettier@3.2.5: {}
 
@@ -4413,6 +5446,13 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  resend@6.9.2:
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.84.1
+
+  resolve-pkg-maps@1.0.0: {}
+
   resolve@1.22.11:
     dependencies:
       is-core-module: 2.16.1
@@ -4429,6 +5469,8 @@ snapshots:
     dependencies:
       glob: 13.0.0
       package-json-from-dist: 1.0.1
+
+  rou3@0.7.12: {}
 
   router@2.2.0:
     dependencies:
@@ -4482,6 +5524,8 @@ snapshots:
       send: 1.2.1
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.2: {}
 
   setprototypeof@1.2.0: {}
 
@@ -4621,6 +5665,11 @@ snapshots:
     dependencies:
       through: 2.3.8
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   stream-combiner@0.0.4:
@@ -4674,6 +5723,11 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  svix@1.84.1:
+    dependencies:
+      standardwebhooks: 1.0.0
+      uuid: 10.0.0
 
   table@6.9.0:
     dependencies:
@@ -4800,6 +5854,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.3
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo-darwin-64@2.8.3:
     optional: true
 
@@ -4858,6 +5919,8 @@ snapshots:
       pako: 1.0.11
 
   util-deprecate@1.0.2: {}
+
+  uuid@10.0.0: {}
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Summary

- **DBパッケージ (`@ubichill/db`)** の新規作成 - Drizzle ORM + PostgreSQL
- **Better Auth認証システム** の統合 - メール + OTP検証フロー
- **Socket.IO認証ミドルウェア** - 接続時にセッション検証
- **World/Instance REST API** の認可強化
- **Helm chart** の DB対応 (PostgreSQL + Sealed Secrets)

## 主な変更点

### データベース
- `@ubichill/db` パッケージ新規作成
- users, worlds, instances テーブルスキーマ
- Drizzle ORM によるリポジトリパターン実装

### 認証
- Better Auth によるメール認証 (OTP 6桁コード)
- OTP検証完了後にのみDBへユーザー作成
- Socket.IO接続時の認証ミドルウェア

### 認可
- ワールド更新・削除: 作成者のみ (403 Forbidden)
- インスタンス削除: リーダーのみ / ユーザー0で自動削除

### インフラ
- Helm chart に PostgreSQL 統合
- Sealed Secrets によるシークレット管理
- SSR向け BACKEND_INTERNAL_URL 導入

## Test plan

- [ ] ユーザー登録フローの確認 (OTP送信 → 検証 → ログイン)
- [ ] Socket.IO接続の認証確認 (未認証時にリダイレクト)
- [ ] ワールドCRUD APIの権限確認 (作成者以外は403)
- [ ] インスタンスの自動削除確認 (ユーザー0で削除)
- [ ] Kubernetes環境でのDB接続確認

## Related Issues

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)