### PR TITLE
ci(chart): validate Helm chart on pull requests

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -1,0 +1,79 @@
+name: Helm Chart CI
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - "charts/**"
+      - ".github/workflows/helm-ci.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
+jobs:
+  validate:
+    name: Validate Helm chart
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: "v3.14.0"
+
+      - name: Add Helm repositories
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm repo update
+
+      - name: Build chart dependencies
+        run: helm dependency build charts/ubichill
+
+      - name: Lint chart with dev values
+        run: |
+          helm lint charts/ubichill \
+            -f charts/ubichill/values-dev.yaml \
+            --set global.domain=dev.example.test \
+            --set postgresql.auth.postgresPassword=test-postgres-password \
+            --set postgresql.auth.password=test-app-password \
+            --set redis.auth.password=test-redis-password
+
+      - name: Lint chart with production values
+        run: |
+          helm lint charts/ubichill \
+            -f charts/ubichill/values-prod.yaml \
+            --set global.domain=prod.example.test \
+            --set backend.secretEnv.BETTER_AUTH_SECRET=test-better-auth-secret \
+            --set backend.secretEnv.RESEND_API_KEY=test-resend-api-key \
+            --set postgresql.auth.postgresPassword=test-postgres-password \
+            --set postgresql.auth.password=test-app-password \
+            --set redis.auth.password=test-redis-password
+
+      - name: Render chart with dev values
+        run: |
+          helm template ubichill-dev charts/ubichill \
+            -f charts/ubichill/values-dev.yaml \
+            --set global.domain=dev.example.test \
+            --set postgresql.auth.postgresPassword=test-postgres-password \
+            --set postgresql.auth.password=test-app-password \
+            --set redis.auth.password=test-redis-password \
+            > /tmp/ubichill-dev.yaml
+
+      - name: Render chart with production values
+        run: |
+          helm template ubichill-prod charts/ubichill \
+            -f charts/ubichill/values-prod.yaml \
+            --set global.domain=prod.example.test \
+            --set backend.secretEnv.BETTER_AUTH_SECRET=test-better-auth-secret \
+            --set backend.secretEnv.RESEND_API_KEY=test-resend-api-key \
+            --set postgresql.auth.postgresPassword=test-postgres-password \
+            --set postgresql.auth.password=test-app-password \
+            --set redis.auth.password=test-redis-password \
+            > /tmp/ubichill-prod.yaml


### PR DESCRIPTION
## 概要

Helm Chart向けのPR検証workflowを追加しました。

## 変更内容

- `charts/ubichill` の依存chartを `helm dependency build` で取得
- `values-dev.yaml` / `values-prod.yaml` の両方で `helm lint`
- `values-dev.yaml` / `values-prod.yaml` の両方で `helm template`
- 本番valuesの必須secret/password/domainは、CI用のダミー値を `--set` で注入

## 背景

READMEにセルフホスト向けのHelm導線があるため、chart変更時にPR段階で最低限renderできることを確認できると安全だと考えました。

既存の `helm-release.yml` はmain push後のpackage/release用途に見えたため、今回はPR時点でのlint / template render確認に絞っています。

## 確認

ローカルで以下を確認しました。

- `helm dependency build charts/ubichill`
- `helm lint charts/ubichill -f charts/ubichill/values-dev.yaml ...`
- `helm lint charts/ubichill -f charts/ubichill/values-prod.yaml ...`
- `helm template ubichill-dev charts/ubichill -f charts/ubichill/values-dev.yaml ...`
- `helm template ubichill-prod charts/ubichill -f charts/ubichill/values-prod.yaml ...`

なお、このPRでは既存のdev自動反映workflowには変更を加えていません。必要であれば、別途 `ci.yml` 側でchart検証を `deploy-dev` の前段に組み込む案も検討できると思います。

もし既存のworkflowやAgent skillsなどによる自動レビューで同等のHelm検証がすでに設定されている場合は機能が重複しちゃうので、その時は遠慮なくこのPRをCloseしてもらって大丈夫です。
