### PR TITLE
feat: mod 完全性ロック（hash固定＋権限天井）＋ @ubichill/loader 分離＋ロック生成CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,56 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+  test:
+    name: Test & Typecheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Extract Node version from package.json
+        id: versions
+        run: |
+          echo "node=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: ${{ steps.versions.outputs.node }}
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      # typecheck はパッケージ間参照が dist 経由のため、shared/db は事前ビルドが要る。
+      # vitest は resolve.alias でソースへ直結するため build 不要（DB統合テストも
+      # DATABASE_URL 未設定時は describe.skipIf で db import 自体をスキップする）。
+      - name: Build shared & db
+        run: |
+          pnpm --filter @ubichill/shared build
+          pnpm --filter @ubichill/db build
+
+      - name: Test
+        run: pnpm exec vitest run
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      # 実際に mod をビルドし、lock.json の integrity が生成バイト列と一致するか検証する。
+      # 単体テストはフェイク値で hash 規約の一致を確認するだけなので、実ビルドでの
+      # fail-closed 検証は別枠で必要（scripts/verify-mod-locks.mjs 参照）。
+      - name: Build mod workers
+        run: pnpm build:workers
+
+      - name: Verify mod locks
+        run: node scripts/verify-mod-locks.mjs
+
   # 変更検知: PR 時はパスフィルタ、push to main では全て true を返す。
   detect-changes:
     name: Detect changed packages
@@ -110,7 +160,7 @@ jobs:
 
   build-backend:
     name: Build and push Backend image
-    needs: [lint, detect-changes]
+    needs: [lint, test, detect-changes]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       (
@@ -168,7 +218,7 @@ jobs:
 
   build-frontend:
     name: Build and push Frontend image
-    needs: [lint, detect-changes]
+    needs: [lint, test, detect-changes]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       (
@@ -228,7 +278,7 @@ jobs:
 
   build-video-player:
     name: Build and push Video Player image
-    needs: [lint, detect-changes]
+    needs: [lint, test, detect-changes]
     if: >
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       (

--- a/.github/workflows/mods-pages.yml
+++ b/.github/workflows/mods-pages.yml
@@ -47,6 +47,11 @@ jobs:
         # dist/mods/ に各modのバンドルが出力される
         run: pnpm build:workers
 
+      # 公開前の fail-closed ゲート: lock.json の integrity が実際に配布するバイト列と
+      # 一致するか独立に再計算して突き合わせる。ズレていれば公開を止める。
+      - name: Verify mod locks
+        run: node scripts/verify-mod-locks.mjs
+
       - name: Checkout gh-pages branch (worktree)
         run: |
           git fetch origin gh-pages --depth=1 2>/dev/null || true

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ CODE_STUDY.md
 
 # Antigravity CLI
 .antigravitycli/
+.playwright-mcp/

--- a/mods/pen/tsconfig.json
+++ b/mods/pen/tsconfig.json
@@ -16,12 +16,7 @@
             "@ubichill/sdk": ["../../packages/sdk/src/index.ts"],
             "@ubichill/sdk/jsx-runtime": ["../../packages/sdk/src/jsx/jsx-runtime.ts"],
             "@ubichill/sdk/gripable": ["../../packages/sdk/src/jsx/Gripable.tsx"],
-            "@ubichill/sdk/*": ["../../packages/sdk/src/*"],
-            "@ubichill/ecs": ["../../packages/ecs/src/index.ts"],
-            "@ubichill/sandbox": ["../../packages/sandbox/src/index.ts"],
-            "@ubichill/sandbox/host": ["../../packages/sandbox/src/host/index.ts"],
-            "@ubichill/react": ["../../packages/react/src/index.ts"],
-            "@ubichill/shared": ["../../packages/shared/src/index.ts"]
+            "@ubichill/sdk/*": ["../../packages/sdk/src/*"]
         }
     },
     "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "docker:up": "node scripts/start-mods.mjs up -d",
     "docker:down": "node scripts/start-mods.mjs down",
     "build:workers": "node scripts/build-workers.mjs",
+    "gen:lock": "tsx packages/loader/src/cli.ts",
     "docs:capabilities": "node scripts/gen-capability-docs.mjs",
     "build": "node scripts/build-workers.mjs && turbo build",
     "lint": "biome check .",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "docker:down": "node scripts/start-mods.mjs down",
     "build:workers": "node scripts/build-workers.mjs",
     "gen:lock": "tsx packages/loader/src/cli.ts",
+    "verify:mod-locks": "node scripts/verify-mod-locks.mjs",
     "docs:capabilities": "node scripts/gen-capability-docs.mjs",
     "build": "node scripts/build-workers.mjs && turbo build",
     "lint": "biome check .",
@@ -36,6 +37,9 @@
       "esbuild",
       "sharp"
     ]
+  },
+  "dependencies": {
+    "@ubichill/shared": "workspace:*"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.13",

--- a/packages/backend/src/handlers/worldHandlers.ts
+++ b/packages/backend/src/handlers/worldHandlers.ts
@@ -298,6 +298,10 @@ export async function sendWorldSnapshot(socket: TypedSocket, instanceId: string,
         availableComponents: [],
         activeMods,
         environment,
+        // mod 完全性ロックと provenance をクライアントへ渡す。外部ワールドは
+        // クライアント側のロード時に lock と hash 照合して不一致 mod を拒否する。
+        lock: world?.lock,
+        sourceKind: world?.source.kind,
     };
     socket.emit('world:snapshot', snapshotPayload);
     logger.debug(

--- a/packages/backend/src/routes/worlds.ts
+++ b/packages/backend/src/routes/worlds.ts
@@ -1,11 +1,23 @@
 import { worldRepository } from '@ubichill/db';
-import { LIMITS, WorldCreateInputSchema, WorldDefinitionSchema } from '@ubichill/shared';
+import { LIMITS, type ModLock, ModLockSchema, WorldCreateInputSchema, WorldDefinitionSchema } from '@ubichill/shared';
 import { Router } from 'express';
 import yaml from 'yaml';
 import { optionalAuth, requireAuth } from '../middleware/auth';
 import { worldRegistry } from '../services/worldRegistry';
 
 const router = Router();
+
+/**
+ * リクエスト body の `lock` を検証する。
+ * - undefined/null → undefined（lock 無しで保存）
+ * - 妥当な ModLock → その値
+ * - それ以外 → 'invalid'（呼び出し側が 400 を返す）
+ */
+function parseOptionalLock(input: unknown): ModLock | undefined | 'invalid' {
+    if (input === undefined || input === null) return undefined;
+    const parsed = ModLockSchema.safeParse(input);
+    return parsed.success ? parsed.data : 'invalid';
+}
 
 /**
  * POST /api/v1/worlds/reload
@@ -171,13 +183,19 @@ router.post('/yaml', requireAuth, async (req, res) => {
             return;
         }
 
-        const { yaml: yamlText } = req.body as { yaml?: unknown };
+        const { yaml: yamlText, lock: lockInput } = req.body as { yaml?: unknown; lock?: unknown };
         if (typeof yamlText !== 'string' || yamlText.length === 0) {
             res.status(400).json({ error: 'yaml フィールドが必要です' });
             return;
         }
         if (yamlText.length > LIMITS.MAX_YAML_SIZE) {
             res.status(413).json({ error: `YAML が大きすぎます（最大 ${LIMITS.MAX_YAML_SIZE} bytes）` });
+            return;
+        }
+        // lock は definition とは別に受け取り別カラム保存する（人間 YAML はクリーンに保つ）。
+        const lock = parseOptionalLock(lockInput);
+        if (lock === 'invalid') {
+            res.status(400).json({ error: 'lock フィールドが不正です' });
             return;
         }
 
@@ -190,7 +208,7 @@ router.post('/yaml', requireAuth, async (req, res) => {
             return;
         }
 
-        const world = await worldRegistry.createFromYaml(req.user.id, req.user.name, yamlText);
+        const world = await worldRegistry.createFromYaml(req.user.id, req.user.name, yamlText, lock);
         res.status(201).json(world);
     } catch (error) {
         const message = error instanceof Error ? error.message : 'YAML 解析に失敗しました';
@@ -249,6 +267,28 @@ router.get('/:worldId/yaml', optionalAuth, async (req, res) => {
 });
 
 /**
+ * GET /api/v1/worlds/:worldId/lock
+ * ワールドの mod 完全性ロックを返す（兄弟ファイル配信）。
+ *
+ * lock は人間が書く YAML には埋めず、この公開エンドポイントで別配信する。
+ * 他インスタンス/クローラが正規 URL から {@link lockUrlFor} で導出して取得する。
+ * lock 未設定のワールドは 404（＝外部 provenance ではロード側で lock-missing 拒否になる）。
+ */
+router.get('/:worldId/lock', optionalAuth, async (req, res) => {
+    try {
+        const lock = await worldRegistry.getWorldLock(req.params.worldId as string);
+        if (!lock) {
+            res.status(404).json({ error: 'Lock not found' });
+            return;
+        }
+        res.json(lock);
+    } catch (error) {
+        console.error('ワールドlock取得エラー:', error);
+        res.status(500).json({ error: 'Internal server error' });
+    }
+});
+
+/**
  * PUT /api/v1/worlds/:worldId/yaml
  * YAML テキストでワールド定義を更新（認証必須、作成者のみ）
  * body: { yaml: string }
@@ -274,13 +314,18 @@ router.put('/:worldId/yaml', requireAuth, async (req, res) => {
             return;
         }
 
-        const { yaml: yamlText } = req.body as { yaml?: unknown };
+        const { yaml: yamlText, lock: lockInput } = req.body as { yaml?: unknown; lock?: unknown };
         if (typeof yamlText !== 'string' || yamlText.length === 0) {
             res.status(400).json({ error: 'yaml フィールドが必要です' });
             return;
         }
         if (yamlText.length > LIMITS.MAX_YAML_SIZE) {
             res.status(413).json({ error: `YAML が大きすぎます（最大 ${LIMITS.MAX_YAML_SIZE} bytes）` });
+            return;
+        }
+        const lock = parseOptionalLock(lockInput);
+        if (lock === 'invalid') {
+            res.status(400).json({ error: 'lock フィールドが不正です' });
             return;
         }
 
@@ -300,7 +345,7 @@ router.put('/:worldId/yaml', requireAuth, async (req, res) => {
             metadata: { ...result.data.metadata, name: worldId },
         };
 
-        const updated = await worldRegistry.updateWorld(worldId, definition);
+        const updated = await worldRegistry.updateWorld(worldId, definition, lock);
         if (!updated) {
             res.status(404).json({ error: 'World not found' });
             return;

--- a/packages/backend/src/services/worldRegistry.ts
+++ b/packages/backend/src/services/worldRegistry.ts
@@ -10,6 +10,7 @@ import {
 import {
     ENV_KEYS,
     type ModLock,
+    ModLockSchema,
     type ResolvedWorld,
     SERVER_CONFIG,
     type WorldCreateInput,
@@ -509,9 +510,12 @@ class WorldRegistry {
             }
             const def = result.data;
             const id = def.metadata.name;
+            // 兄弟 `<name>.lock.json` があれば読み込む（分離方針＝YAML には埋めない）。
+            const lock = this._readSiblingLock(filePath);
             // official ワールドは DB に持たずメモリ索引のみ（DB 依存の排除）
             const resolved = definitionToResolved(parsed, this.selfWorldUrl(id), this.localSource(id), {
                 authorId: SYSTEM_AUTHOR_ID,
+                lock,
             });
             this._index.set(id, resolved);
             this._urlIndex.set(resolved.url, id);
@@ -520,6 +524,18 @@ class WorldRegistry {
             return resolved;
         } catch (err) {
             console.error(`❌ ローカルワールド読み込み失敗: ${filePath}`, err);
+            return undefined;
+        }
+    }
+
+    /** official ワールド YAML の兄弟 `<name>.lock.json` を読む（fs 版 sibling lock）。無ければ undefined。 */
+    private _readSiblingLock(worldFilePath: string): ModLock | undefined {
+        const lockPath = worldFilePath.replace(/\.ya?ml$/i, '.lock.json');
+        if (!fs.existsSync(lockPath)) return undefined;
+        try {
+            const parsed = ModLockSchema.safeParse(JSON.parse(fs.readFileSync(lockPath, 'utf-8')));
+            return parsed.success ? parsed.data : undefined;
+        } catch {
             return undefined;
         }
     }

--- a/packages/backend/src/services/worldRegistry.ts
+++ b/packages/backend/src/services/worldRegistry.ts
@@ -9,6 +9,7 @@ import {
 } from '@ubichill/db';
 import {
     ENV_KEYS,
+    type ModLock,
     type ResolvedWorld,
     SERVER_CONFIG,
     type WorldCreateInput,
@@ -350,12 +351,13 @@ class WorldRegistry {
 
     // ---- CRUD（ユーザー操作） ----------------------------------------
 
-    async createWorld(authorId: string, definition: WorldDefinition): Promise<ResolvedWorld> {
+    async createWorld(authorId: string, definition: WorldDefinition, lock?: ModLock | null): Promise<ResolvedWorld> {
         const record = await worldRepository.create({
             authorId,
             name: definition.metadata.name,
             version: definition.metadata.version,
             definition,
+            lock: lock ?? null,
         });
         const resolved = this._resolveWorld(record);
         this._resolvedCache.set(resolved.id, resolved);
@@ -388,13 +390,21 @@ class WorldRegistry {
      * YAML テキストからワールドを作成する。
      * metadata.name は無視してサーバー側で再生成し、所有権を作成者に紐付ける。
      */
-    async createFromYaml(authorId: string, authorDisplayName: string, yamlText: string): Promise<ResolvedWorld> {
+    async createFromYaml(
+        authorId: string,
+        authorDisplayName: string,
+        yamlText: string,
+        lock?: ModLock | null,
+    ): Promise<ResolvedWorld> {
         const parsed = migrateLegacyWorldYaml(yaml.parse(yamlText) as unknown);
         const result = WorldDefinitionSchema.safeParse(parsed);
         if (!result.success) {
             const issue = result.error.issues[0];
             throw new Error(`YAML が不正です: ${issue?.path.join('.') ?? ''} ${issue?.message ?? ''}`);
         }
+        // 人間が書く definition と lock は分離保存する。埋め込み spec.lock が来ても
+        // 別カラム保存へ寄せ、definition からは落とす（fallback は別配信できない外部用）。
+        const { lock: embeddedLock, ...cleanSpec } = result.data.spec;
         const def: WorldDefinition = {
             ...result.data,
             metadata: {
@@ -402,19 +412,26 @@ class WorldRegistry {
                 name: generateWorldId(),
                 author: result.data.metadata.author ?? { name: authorDisplayName },
             },
+            spec: cleanSpec,
         };
-        return this.createWorld(authorId, def);
+        return this.createWorld(authorId, def, lock ?? embeddedLock ?? null);
     }
 
     // NOTE: 外部/リモートのワールドは DB にコピーしない（＝連合は参照のみ）。
     // 単発で入るなら resolveRef(URL)→instance 作成、永続的に見たいならピアをフォローする。
 
-    async updateWorld(worldId: string, definition: WorldDefinition): Promise<ResolvedWorld | undefined> {
+    async updateWorld(
+        worldId: string,
+        definition: WorldDefinition,
+        lock?: ModLock | null,
+    ): Promise<ResolvedWorld | undefined> {
         const existing = await worldRepository.findByName(worldId);
         if (!existing) return undefined;
+        const { lock: embeddedLock, ...cleanSpec } = definition.spec;
         const updated = await worldRepository.update(existing.id, {
             version: definition.metadata.version,
-            definition,
+            definition: { ...definition, spec: cleanSpec },
+            lock: lock ?? embeddedLock ?? null,
         });
         if (!updated) return undefined;
         const resolved = this._resolveWorld(updated);
@@ -581,9 +598,20 @@ class WorldRegistry {
         return {
             ...definitionToResolved(def, this.selfWorldUrl(record.name), this.localSource(record.name), {
                 authorId: record.authorId,
+                lock: record.lock ?? undefined,
             }),
             id: record.name,
         };
+    }
+
+    /**
+     * ワールドの mod ロックを返す（兄弟エンドポイント /worlds/:id/lock 用）。
+     * DB ユーザーワールドは別カラム、official（ファイル）は解決済み ResolvedWorld.lock から。
+     */
+    async getWorldLock(worldId: string): Promise<ModLock | undefined> {
+        const record = await worldRepository.findByName(worldId);
+        if (record) return record.lock ?? undefined;
+        return this._index.get(worldId)?.lock;
     }
 
     /** ResolvedWorld(+DB record) → WorldListItem。 */

--- a/packages/backend/src/services/worldResolver.test.ts
+++ b/packages/backend/src/services/worldResolver.test.ts
@@ -1,6 +1,12 @@
 import { WorldSourceKind } from '@ubichill/shared';
 import { describe, expect, it } from 'vitest';
-import { definitionToResolved, normalizeWorldUrl, resolveWorldFromYaml, toRawGitHubUrl } from './worldResolver';
+import {
+    definitionToResolved,
+    lockUrlFor,
+    normalizeWorldUrl,
+    resolveWorldFromYaml,
+    toRawGitHubUrl,
+} from './worldResolver';
 
 const VALID_YAML = `
 apiVersion: ubichill.com/v1alpha1
@@ -49,6 +55,26 @@ describe('normalizeWorldUrl', () => {
     });
     it('不正な文字列は入力を返す', () => {
         expect(normalizeWorldUrl('not a url')).toBe('not a url');
+    });
+});
+
+describe('lockUrlFor（mod ロックの兄弟 URL 導出）', () => {
+    it('機械 URL(.../api/v1/worlds/:id) → .../lock', () => {
+        expect(lockUrlFor('https://h.example/api/v1/worlds/abc')).toBe('https://h.example/api/v1/worlds/abc/lock');
+    });
+    it('/yaml サフィックス付きでも同じ lock URL を導出する', () => {
+        expect(lockUrlFor('https://h.example/api/v1/worlds/abc/yaml')).toBe('https://h.example/api/v1/worlds/abc/lock');
+    });
+    it('直 YAML URL は拡張子を .lock.json に置換（GitHub raw 等）', () => {
+        expect(lockUrlFor('https://raw.githubusercontent.com/o/r/main/worlds/x.yaml')).toBe(
+            'https://raw.githubusercontent.com/o/r/main/worlds/x.lock.json',
+        );
+        expect(lockUrlFor('https://cdn.example/foo.yml')).toBe('https://cdn.example/foo.lock.json');
+    });
+    it('ワールド一覧や兄弟を導出できない URL は null（埋め込みフォールバックに委ねる）', () => {
+        expect(lockUrlFor('https://h.example/api/v1/worlds')).toBeNull();
+        expect(lockUrlFor('https://example.com/some/page')).toBeNull();
+        expect(lockUrlFor('not a url')).toBeNull();
     });
 });
 

--- a/packages/backend/src/services/worldResolver.ts
+++ b/packages/backend/src/services/worldResolver.ts
@@ -115,6 +115,7 @@ function mapToResolved(
         dependencies: def.spec.dependencies?.map((d) => ({ name: d.name, source: d.source })),
         initialEntities,
         mods: collectMods(initialEntities, def.spec.dependencies),
+        lock: def.spec.lock,
     };
 }
 

--- a/packages/backend/src/services/worldResolver.ts
+++ b/packages/backend/src/services/worldResolver.ts
@@ -16,6 +16,8 @@ import {
     DEFAULTS,
     type InitialEntity,
     LIMITS,
+    type ModLock,
+    ModLockSchema,
     type ResolvedWorld,
     type WorldDefinition,
     WorldDefinitionSchema,
@@ -63,9 +65,47 @@ export function definitionToResolved(
     parsed: unknown,
     url: string,
     source: WorldSource,
-    extra?: { authorId?: string },
+    extra?: { authorId?: string; lock?: ModLock },
 ): ResolvedWorld {
     return mapToResolved(validateWorldDefinition(parsed, url), url, source, extra);
+}
+
+/**
+ * ワールド URL から mod ロックの兄弟 URL を導出する。
+ * lock は YAML に埋めず別配信するため、解決側はここが指す先を best-effort で取りに行く。
+ * - ubichill 機械 URL `.../api/v1/worlds/:id`(`/yaml`可) → `.../api/v1/worlds/:id/lock`
+ * - 直 YAML URL `*.yaml` / `*.yml`（GitHub raw 等）→ 拡張子を `.lock.json` に置換
+ * - それ以外 → null（兄弟なし。埋め込み `spec.lock` フォールバックに委ねる）
+ */
+export function lockUrlFor(worldUrl: string): string | null {
+    try {
+        const u = new URL(worldUrl);
+        const api = /^(\/api\/v1\/worlds\/[^/]+?)(?:\/yaml)?\/?$/.exec(u.pathname);
+        if (api) return `${u.origin}${api[1]}/lock`;
+        if (/\.ya?ml$/i.test(u.pathname)) {
+            return `${u.origin}${u.pathname.replace(/\.ya?ml$/i, '.lock.json')}${u.search}`;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * 兄弟 URL から mod ロックを best-effort で取得する。取得不能・不正は undefined。
+ * 失敗しても解決自体は続行し、埋め込み `spec.lock` フォールバックに委ねる。
+ */
+async function fetchSiblingLock(worldUrl: string): Promise<ModLock | undefined> {
+    const lockUrl = lockUrlFor(worldUrl);
+    if (!lockUrl) return undefined;
+    try {
+        const res = await safeFetch(lockUrl, { headers: { Accept: 'application/json' } });
+        if (!res.ok) return undefined;
+        const parsed = ModLockSchema.safeParse(await res.json());
+        return parsed.success ? parsed.data : undefined;
+    } catch {
+        return undefined;
+    }
 }
 
 /** unknown をパース・マイグレーション・検証して WorldDefinition にする（不正は throw）。 */
@@ -83,7 +123,7 @@ function mapToResolved(
     def: WorldDefinition,
     url: string,
     source: WorldSource,
-    extra?: { authorId?: string },
+    extra?: { authorId?: string; lock?: ModLock },
 ): ResolvedWorld {
     const env = def.spec.environment ?? {
         backgroundColor: DEFAULTS.WORLD_ENVIRONMENT.backgroundColor,
@@ -115,7 +155,8 @@ function mapToResolved(
         dependencies: def.spec.dependencies?.map((d) => ({ name: d.name, source: d.source })),
         initialEntities,
         mods: collectMods(initialEntities, def.spec.dependencies),
-        lock: def.spec.lock,
+        // 別配信の lock（兄弟ファイル / DB カラム）を優先し、無ければ埋め込みフォールバック。
+        lock: extra?.lock ?? def.spec.lock,
     };
 }
 
@@ -157,9 +198,10 @@ export function resolveWorldFromYaml(
 /** URL を取得して ResolvedWorld に解決する（外部/他インスタンス用）。 */
 export async function resolveWorldFromUrl(url: string, source: WorldSource): Promise<ResolvedWorld> {
     const fetchUrl = toRawGitHubUrl(url);
-    const text = await fetchText(fetchUrl);
+    // 本体 YAML と兄弟 lock を並行取得（lock は best-effort・失敗しても続行）。
+    const [text, lock] = await Promise.all([fetchText(fetchUrl), fetchSiblingLock(url)]);
     // 正規 URL は元の（人間が貼れる）URL を維持する
-    return resolveWorldFromYaml(text, url, source);
+    return definitionToResolved(yaml.parse(text), url, source, { lock });
 }
 
 /** URL を取得し、生定義（配信用）と ResolvedWorld（一覧/入室用）の両方を返す。 */
@@ -167,9 +209,9 @@ export async function resolveWorld(
     url: string,
     source: WorldSource,
 ): Promise<{ definition: WorldDefinition; resolved: ResolvedWorld }> {
-    const text = await fetchText(toRawGitHubUrl(url));
+    const [text, lock] = await Promise.all([fetchText(toRawGitHubUrl(url)), fetchSiblingLock(url)]);
     const definition = validateWorldDefinition(yaml.parse(text), url);
-    return { definition, resolved: definitionToResolved(definition, url, source) };
+    return { definition, resolved: definitionToResolved(definition, url, source, { lock }) };
 }
 
 // ============================================================

--- a/packages/backend/src/services/worldResolver.ts
+++ b/packages/backend/src/services/worldResolver.ts
@@ -13,6 +13,7 @@
  */
 
 import {
+    collectModIds,
     DEFAULTS,
     type InitialEntity,
     LIMITS,
@@ -171,16 +172,8 @@ function collectMods(
     const versionByName = new Map<string, string | undefined>();
     for (const d of dependencies ?? []) versionByName.set(d.name, d.source?.version);
 
-    const ids = new Set<string>();
-    const walk = (e: InitialEntity): void => {
-        for (const c of e.components) {
-            const modId = c.type.split(':')[0];
-            if (modId) ids.add(modId);
-        }
-        for (const child of e.children ?? []) walk(child);
-    };
-    for (const e of entities) walk(e);
-    for (const name of versionByName.keys()) ids.add(name);
+    // entity 走査は shared の collectModIds に一本化。dependency 宣言分を足す。
+    const ids = new Set<string>([...collectModIds(entities), ...versionByName.keys()]);
 
     return [...ids].map((id) => ({ id, version: versionByName.get(id) }));
 }

--- a/packages/db/drizzle/0003_furry_johnny_blaze.sql
+++ b/packages/db/drizzle/0003_furry_johnny_blaze.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "worlds" ADD COLUMN "lock" jsonb;

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,850 @@
+{
+  "id": "d7fdee5d-d361-4f65-aec4-642b46da1838",
+  "prevId": "e04885f9-2a08-4688-acd7-6fa5bfab37cc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.federation_peers": {
+      "name": "federation_peers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "base_url": {
+          "name": "base_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "federation_peers_base_url_unique": {
+          "name": "federation_peers_base_url_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "base_url"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.instances": {
+      "name": "instances",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "world_ref": {
+          "name": "world_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "leader_id": {
+          "name": "leader_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "instance_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "access_type": {
+          "name": "access_type",
+          "type": "instance_access_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "access_tags": {
+          "name": "access_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "has_password": {
+          "name": "has_password",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_users": {
+          "name": "max_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "current_users": {
+          "name": "current_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "instances_world_ref_idx": {
+          "name": "instances_world_ref_idx",
+          "columns": [
+            {
+              "expression": "world_ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_status_idx": {
+          "name": "instances_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "instances_leader_id_idx": {
+          "name": "instances_leader_id_idx",
+          "columns": [
+            {
+              "expression": "leader_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "instances_leader_id_users_id_fk": {
+          "name": "instances_leader_id_users_id_fk",
+          "tableFrom": "instances",
+          "tableTo": "users",
+          "columnsFrom": [
+            "leader_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_user_id_users_id_fk": {
+          "name": "accounts_user_id_users_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "sessions_token_unique": {
+          "name": "sessions_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_favorites": {
+      "name": "user_favorites",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "world_ref": {
+          "name": "world_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_favorites_user_id_users_id_fk": {
+          "name": "user_favorites_user_id_users_id_fk",
+          "tableFrom": "user_favorites",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_favorites_user_id_world_ref_pk": {
+          "name": "user_favorites_user_id_world_ref_pk",
+          "columns": [
+            "user_id",
+            "world_ref"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_friends": {
+      "name": "user_friends",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "friend_id": {
+          "name": "friend_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "friend_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_friends_user_id_users_id_fk": {
+          "name": "user_friends_user_id_users_id_fk",
+          "tableFrom": "user_friends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_friends_friend_id_users_id_fk": {
+          "name": "user_friends_friend_id_users_id_fk",
+          "tableFrom": "user_friends",
+          "tableTo": "users",
+          "columnsFrom": [
+            "friend_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_friends_user_id_friend_id_pk": {
+          "name": "user_friends_user_id_friend_id_pk",
+          "columns": [
+            "user_id",
+            "friend_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_settings": {
+      "name": "user_settings",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "disable_external_urls": {
+          "name": "disable_external_urls",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_settings_user_id_users_id_fk": {
+          "name": "user_settings_user_id_users_id_fk",
+          "tableFrom": "user_settings",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_image_url": {
+          "name": "profile_image_url",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_username_unique": {
+          "name": "users_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verifications": {
+      "name": "verifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.worlds": {
+      "name": "worlds",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(21)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "lock": {
+          "name": "lock",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "worlds_author_id_users_id_fk": {
+          "name": "worlds_author_id_users_id_fk",
+          "tableFrom": "worlds",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "worlds_name_unique": {
+          "name": "worlds_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.instance_access_type": {
+      "name": "instance_access_type",
+      "schema": "public",
+      "values": [
+        "public",
+        "friend_plus",
+        "friend_only",
+        "invite_only"
+      ]
+    },
+    "public.instance_status": {
+      "name": "instance_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "full",
+        "closing"
+      ]
+    },
+    "public.friend_status": {
+      "name": "friend_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "accepted"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1784782608630,
       "tag": "0002_steep_bug",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1785132402347,
+      "tag": "0003_furry_johnny_blaze",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/repositories/worldRepository.ts
+++ b/packages/db/src/repositories/worldRepository.ts
@@ -1,4 +1,4 @@
-import type { WorldDefinition } from '@ubichill/shared';
+import type { ModLock, WorldDefinition } from '@ubichill/shared';
 import { count, eq } from 'drizzle-orm';
 import { db } from '../index';
 import { worlds } from '../schema';
@@ -8,12 +8,15 @@ export interface CreateWorldInput {
     name: string;
     version: string;
     definition: WorldDefinition;
+    /** mod 完全性ロック（definition とは別カラムに保存）。 */
+    lock?: ModLock | null;
 }
 
 export interface UpdateWorldInput {
     name?: string;
     version?: string;
     definition?: WorldDefinition;
+    lock?: ModLock | null;
 }
 
 export type WorldRecord = typeof worlds.$inferSelect;
@@ -73,6 +76,7 @@ export const worldRepository = {
                 name: input.name,
                 version: input.version,
                 definition: input.definition,
+                lock: input.lock ?? null,
             })
             .returning();
         return results[0];
@@ -110,6 +114,7 @@ export const worldRepository = {
             const updated = await this.update(existing.id, {
                 version: input.version,
                 definition: input.definition,
+                lock: input.lock ?? null,
             });
             // updateは既存レコードを更新するので、必ずWorldRecordが返る
             if (!updated) {

--- a/packages/db/src/schema/index.ts
+++ b/packages/db/src/schema/index.ts
@@ -1,4 +1,4 @@
-import { WorldDefinitionSchema } from '@ubichill/shared';
+import { ModLockSchema, WorldDefinitionSchema } from '@ubichill/shared';
 import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 import { z } from 'zod';
 
@@ -36,10 +36,12 @@ export const selectFederationPeerSchema = createSelectSchema(federationPeers);
 // worlds
 export const insertWorldSchema = createInsertSchema(worlds, {
     definition: WorldDefinitionSchema,
+    lock: ModLockSchema.optional().nullable(),
 });
 
 export const selectWorldSchema = createSelectSchema(worlds, {
     definition: WorldDefinitionSchema,
+    lock: ModLockSchema.nullable(),
 });
 
 // instances

--- a/packages/db/src/schema/worlds.ts
+++ b/packages/db/src/schema/worlds.ts
@@ -1,4 +1,4 @@
-import type { WorldDefinition } from '@ubichill/shared';
+import type { ModLock, WorldDefinition } from '@ubichill/shared';
 import { relations } from 'drizzle-orm';
 import { jsonb, pgTable, text, timestamp, varchar } from 'drizzle-orm/pg-core';
 import { nanoid } from 'nanoid';
@@ -14,6 +14,9 @@ export const worlds = pgTable('worlds', {
     name: varchar('name', { length: 255 }).notNull().unique(),
     version: varchar('version', { length: 50 }).notNull(),
     definition: jsonb('definition').$type<WorldDefinition>().notNull(),
+    // mod 完全性ロック。人間が書く definition とは分離して別カラムに保存し、
+    // 配信時は兄弟エンドポイント（/worlds/:id/lock）で返す。null 可（未ロックの旧世界）。
+    lock: jsonb('lock').$type<ModLock>(),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -13,6 +13,7 @@
         "format": "biome format --write ."
     },
     "dependencies": {
+        "@ubichill/loader": "workspace:*",
         "@ubichill/react": "workspace:*",
         "@ubichill/sdk": "workspace:*",
         "@ubichill/shared": "workspace:*",

--- a/packages/frontend/src/mods/ModRegistryContext.tsx
+++ b/packages/frontend/src/mods/ModRegistryContext.tsx
@@ -1,158 +1,14 @@
 import type { WidgetDefinition, WorkerModDefinition } from '@ubichill/react';
 import { isWorkerMod } from '@ubichill/react';
+import { type ModLock, WorldSourceKind } from '@ubichill/shared';
 import type React from 'react';
 import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+import { loadVerifiedMod } from './modLoader';
 
 // ============================================
-// mod.json 自動ローダー
+// mod ローダー（取得 + lock 照合は modLoader.ts に委譲）
+// このファイルは React の state / キャッシュ / register だけを持つ。
 // ============================================
-
-/**
- * ルート mod.json（バージョン index）。
- * npm の package endpoint と同様に「最新バージョンへのポインタ」としてのみ機能する。
- * エンティティ詳細はバージョン付きマニフェストに分離されている。
- */
-interface ModIndex {
-    id: string;
-    name?: string;
-    version: string;
-}
-
-/**
- * バージョン付きマニフェスト（/mods/<name>/v<ver>/manifest.json）の Component 定義。
- * ビルド時のみ必要な src フィールドは含まない。
- * workerUrl はバージョンディレクトリからの相対パス（例: "./cursor/index.js"）。
- *
- * workerUrl が無いエントリは「データ専用 Component」(mod.json で src 未定義) で、
- * worker は起動せず manifest 上のメタ情報のみを表す。
- */
-interface WorkerMetaObject {
-    workerUrl?: string;
-    capabilities?: string[];
-    singleton?: boolean;
-    canvasTargets?: string[];
-    watchEntityTypes?: string[];
-    /** 'entity' | 'subtree' (default) | 'parent' | 'world' */
-    watchScope?: 'entity' | 'subtree' | 'parent' | 'world';
-    /** アセット相対パス */
-    thumbnail?: string;
-    mediaTargets?: string[];
-    defaultTransform?: Record<string, unknown>;
-    dataFields?: Record<string, unknown>;
-}
-
-/** バージョン付きマニフェスト全体（Stage 1: `components` キーで全 Component を `modId:componentName` 形式で保持） */
-interface VersionedModJson {
-    id: string;
-    name?: string;
-    version: string;
-    components?: Record<string, WorkerMetaObject>;
-}
-
-/**
- * modのベースURL。
- * VITE_MOD_CDN_URL が設定されている場合はそちらを使う（外部CDN / GitHub Pages）。
- * 未設定の場合は自ホストの /mods/ に相対パスでアクセスする。
- */
-const MOD_BASE_URL: string = (() => {
-    const envUrl = import.meta.env.VITE_MOD_CDN_URL as string | undefined;
-    if (envUrl) return envUrl.replace(/\/$/, '');
-    return '/mods';
-})();
-
-/** mod名 → ルート index のキャッシュ */
-const modIndexCache = new Map<string, Promise<ModIndex | null>>();
-/** "modName@version" → バージョン付きマニフェストのキャッシュ */
-const versionedManifestCache = new Map<string, Promise<VersionedModJson | null>>();
-
-function fetchModIndex(modName: string): Promise<ModIndex | null> {
-    if (!modIndexCache.has(modName)) {
-        modIndexCache.set(
-            modName,
-            fetch(`${MOD_BASE_URL}/${modName}/mod.json`, { cache: 'no-store' })
-                .then((r) => (r.ok ? (r.json() as Promise<ModIndex>) : null))
-                .catch(() => null),
-        );
-    }
-    return modIndexCache.get(modName) ?? Promise.resolve(null);
-}
-
-function fetchVersionedManifest(modName: string, version: string): Promise<VersionedModJson | null> {
-    const key = `${modName}@${version}`;
-    if (!versionedManifestCache.has(key)) {
-        versionedManifestCache.set(
-            key,
-            // cache: 'no-store' — manifest はビルド毎に workerUrl のハッシュが変わるため、
-            // 開発時に古いハッシュ参照を掴まされないようブラウザキャッシュを必ず迂回する。
-            fetch(`${MOD_BASE_URL}/${modName}/v${version}/manifest.json`, { cache: 'no-store' })
-                .then((r) => (r.ok ? (r.json() as Promise<VersionedModJson>) : null))
-                .catch(() => null),
-        );
-    }
-    return versionedManifestCache.get(key) ?? Promise.resolve(null);
-}
-
-/**
- * loadWorkerMod の戻り値。
- *  - 'data-only': manifest に宣言されているが workerUrl が無い純データ Component。
- *    spawn して持ち回るだけのエンティティ (例: pen:stroke)。warning は出さない。
- *  - 'not-found': manifest 取得失敗 / manifest に宣言されていない。古い YAML が
- *    廃止modを参照している可能性。warning を出して skip。
- */
-type LoadResult = WorkerModDefinition | 'data-only' | 'not-found';
-
-/**
- * Component 型 (`modName:componentName`) から WorkerModDefinition を構築する。
- * 該当するmodがない or workerUrl が無いデータ専用 Component の場合は null。
- */
-async function loadWorkerMod(entityType: string): Promise<LoadResult> {
-    const colonIdx = entityType.indexOf(':');
-    if (colonIdx === -1) return 'not-found'; // entityType は必ずコロン形式
-
-    const modName = entityType.slice(0, colonIdx);
-    const index = await fetchModIndex(modName);
-    if (!index?.version) return 'not-found';
-
-    const manifest = await fetchVersionedManifest(modName, index.version);
-    const entry = manifest?.components?.[entityType];
-    if (!entry) return 'not-found';
-    if (!entry.workerUrl) return 'data-only';
-
-    const versionedBase = `${MOD_BASE_URL}/${modName}/v${index.version}`;
-    const workerUrl = `${versionedBase}/${entry.workerUrl.replace(/^\.\//, '')}`;
-
-    let workerCode: string;
-    try {
-        const res = await fetch(workerUrl);
-        if (!res.ok) return 'not-found';
-        // Vite の SPA fallback などで HTML が返ったとき (= worker file 404 で index.html が来る) は
-        // text/javascript を期待しているので拒否する。これが無いと mod code に <!DOCTYPE html>
-        // が入って sandbox の new Function() が `Unexpected token '<'` で死ぬ。
-        const ct = res.headers.get('content-type') ?? '';
-        if (!ct.includes('javascript') && !ct.includes('text/plain') && ct !== '') {
-            console.warn(`[ModRegistry] worker fetch returned non-JS content-type "${ct}" for ${entityType}`);
-            return 'not-found';
-        }
-        workerCode = await res.text();
-    } catch {
-        return 'not-found';
-    }
-
-    const def: WorkerModDefinition = {
-        id: entityType,
-        name: `${manifest?.name ?? modName} - ${entityType.slice(colonIdx + 1)}`,
-        workerCode,
-        capabilities: entry.capabilities,
-        singleton: entry.singleton,
-        canvasTargets: entry.canvasTargets,
-        watchEntityTypes: entry.watchEntityTypes,
-        watchScope: entry.watchScope ?? 'subtree',
-        thumbnail: entry.thumbnail,
-        mediaTargets: entry.mediaTargets,
-        modBase: versionedBase,
-    };
-    return def;
-}
 
 // ============================================
 // Types
@@ -191,7 +47,14 @@ const ModRegistryContext = createContext<ModRegistryContextType>({
 export const ModRegistryProvider: React.FC<{
     children: React.ReactNode;
     onStatusChange?: (status: ModLoadingStatus) => void;
-}> = ({ children, onStatusChange }) => {
+    /** ワールドに焼かれた mod 完全性ロック。外部 provenance では hash 照合に使う。 */
+    lock?: ModLock;
+    /**
+     * ワールドの provenance kind（local/github/...）。lock enforcement の分岐に使う。
+     * 未指定（エディタプレビュー等）は local として寛容に扱う。
+     */
+    sourceKind?: string;
+}> = ({ children, onStatusChange, lock, sourceKind = WorldSourceKind.Local }) => {
     const [modMap, setModMap] = useState<Map<string, AnyModDefinition>>(new Map());
     const [loadCounts, setLoadCounts] = useState<ModLoadingStatus>({ completed: 0, total: 0 });
     const pendingModCount = loadCounts.total - loadCounts.completed;
@@ -240,15 +103,23 @@ export const ModRegistryProvider: React.FC<{
             loadingRef.current.add(entityType);
             setLoadCounts((c) => ({ ...c, total: c.total + 1 }));
 
-            loadWorkerMod(entityType)
+            loadVerifiedMod(entityType, { lock, sourceKind })
                 .then((result) => {
-                    if (typeof result === 'object') {
+                    if (typeof result === 'object' && 'workerCode' in result) {
                         addMod(result);
                         return;
                     }
                     if (result === 'data-only') {
                         // manifest に宣言されているがworkerなし。spawn して持ち回るだけのエンティティ
                         // (例: pen:stroke)。Worker を起動しないし、警告も出さない。
+                        loadingRef.current.delete(entityType);
+                        return;
+                    }
+                    if (typeof result === 'object' && 'rejected' in result) {
+                        // lock 照合に失敗した外部 mod。安全のため実行しない。
+                        console.warn(
+                            `[ModRegistry] component "${entityType}" は lock 照合に失敗 (${result.rejected})。実行を拒否します。`,
+                        );
                         loadingRef.current.delete(entityType);
                         return;
                     }
@@ -267,7 +138,7 @@ export const ModRegistryProvider: React.FC<{
                     setLoadCounts((c) => ({ ...c, completed: c.completed + 1 }));
                 });
         },
-        [addMod],
+        [addMod, lock, sourceKind],
     );
 
     // dependencies が登録されているからといって全 worker を一括起動しない。

--- a/packages/frontend/src/mods/buildWorldLock.ts
+++ b/packages/frontend/src/mods/buildWorldLock.ts
@@ -7,8 +7,20 @@ import { buildWorldLock as build, collectModIds, createHttpLockEntryGetter } fro
 import type { ModLock, WorldDefinition } from '@ubichill/shared';
 import { MOD_BASE_URL } from './modLoader';
 
-/** ワールド定義から mod 完全性ロックを構築する（HTTP 経由で各 mod の lock.json 断片を取得）。 */
+/**
+ * ワールド定義から mod 完全性ロックを構築する（HTTP 経由で各 mod の lock.json 断片を取得）。
+ * lock 化できなかった mod があれば警告する（＝外部公開時にその mod は lock-missing 拒否になる）。
+ * ローカル用途では寛容に読めるためブロックはしない。
+ */
 export async function buildWorldLock(definition: WorldDefinition): Promise<ModLock> {
     const modIds = collectModIds(definition.spec.initialEntities);
-    return build(modIds, createHttpLockEntryGetter(MOD_BASE_URL));
+    const lock = await build(modIds, createHttpLockEntryGetter(MOD_BASE_URL));
+    const missing = modIds.filter((id) => !(id in lock.mods));
+    if (missing.length > 0) {
+        console.warn(
+            `[buildWorldLock] lock 断片を取得できず lock 化できない mod: ${missing.join(', ')}` +
+                `（外部公開時はこの mod がロード拒否される）`,
+        );
+    }
+    return lock;
 }

--- a/packages/frontend/src/mods/buildWorldLock.ts
+++ b/packages/frontend/src/mods/buildWorldLock.ts
@@ -1,0 +1,56 @@
+/**
+ * buildWorldLock — ワールド保存時に mod 完全性ロックを組み立てる。
+ *
+ * 各 mod がビルド時に出力した `v<ver>/lock.json`（ModLockEntry）を取得し、
+ * ワールドが参照する mod だけを集めて {@link ModLock} を作る。これを spec.lock に
+ * 焼き込むことで、以降このワールドを読むクライアントは lock と hash 照合できる。
+ *
+ * 「誰が lock を書いたか」は信頼不要 — 安全性はロード時照合（modLoader）が担保する。
+ * ここは保存時に「今の bytes を固定する」だけの取得層。
+ */
+import type { InitialEntity, ModLock, ModLockEntry, WorldDefinition } from '@ubichill/shared';
+import { ModLockEntrySchema } from '@ubichill/shared';
+import { MOD_BASE_URL } from './modLoader';
+
+/** initialEntities ツリーを辿り、使用 mod の modId を重複なく集める純関数。 */
+function collectModIds(entities: InitialEntity[]): string[] {
+    const ids = new Set<string>();
+    const walk = (e: InitialEntity): void => {
+        for (const c of e.components) {
+            const modId = c.type.split(':')[0];
+            if (modId) ids.add(modId);
+        }
+        for (const child of e.children ?? []) walk(child);
+    };
+    for (const e of entities) walk(e);
+    return [...ids];
+}
+
+/** 1 mod の lock.json（ModLockEntry）を取得・検証する。取得不能なら null。 */
+async function fetchModLockEntry(modId: string): Promise<ModLockEntry | null> {
+    try {
+        const index = await fetch(`${MOD_BASE_URL}/${modId}/mod.json`, { cache: 'no-store' });
+        if (!index.ok) return null;
+        const { version } = (await index.json()) as { version?: string };
+        if (!version) return null;
+
+        const res = await fetch(`${MOD_BASE_URL}/${modId}/v${version}/lock.json`, { cache: 'no-store' });
+        if (!res.ok) return null;
+        const parsed = ModLockEntrySchema.safeParse(await res.json());
+        return parsed.success ? parsed.data : null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * ワールド定義から mod 完全性ロックを構築する。
+ * 取得できなかった mod は lock から除外する（＝外部公開時、そのワールドを読む側で
+ * lock-missing 拒否になる。UI 側で欠落 mod を警告するのが望ましい）。
+ */
+export async function buildWorldLock(definition: WorldDefinition): Promise<ModLock> {
+    const modIds = collectModIds(definition.spec.initialEntities);
+    const entries = await Promise.all(modIds.map(async (id) => [id, await fetchModLockEntry(id)] as const));
+    const mods = Object.fromEntries(entries.filter((e): e is [string, ModLockEntry] => e[1] !== null));
+    return { lockVersion: 1, mods };
+}

--- a/packages/frontend/src/mods/buildWorldLock.ts
+++ b/packages/frontend/src/mods/buildWorldLock.ts
@@ -1,56 +1,14 @@
 /**
- * buildWorldLock — ワールド保存時に mod 完全性ロックを組み立てる。
+ * buildWorldLock（frontend アダプタ）— ワールド保存時に mod 完全性ロックを組み立てる。
  *
- * 各 mod がビルド時に出力した `v<ver>/lock.json`（ModLockEntry）を取得し、
- * ワールドが参照する mod だけを集めて {@link ModLock} を作る。これを spec.lock に
- * 焼き込むことで、以降このワールドを読むクライアントは lock と hash 照合できる。
- *
- * 「誰が lock を書いたか」は信頼不要 — 安全性はロード時照合（modLoader）が担保する。
- * ここは保存時に「今の bytes を固定する」だけの取得層。
+ * 収集・取得・構築の中核は @ubichill/loader。ここは baseUrl（MOD_BASE_URL）を注入するだけ。
  */
-import type { InitialEntity, ModLock, ModLockEntry, WorldDefinition } from '@ubichill/shared';
-import { ModLockEntrySchema } from '@ubichill/shared';
+import { buildWorldLock as build, collectModIds, createHttpLockEntryGetter } from '@ubichill/loader';
+import type { ModLock, WorldDefinition } from '@ubichill/shared';
 import { MOD_BASE_URL } from './modLoader';
 
-/** initialEntities ツリーを辿り、使用 mod の modId を重複なく集める純関数。 */
-function collectModIds(entities: InitialEntity[]): string[] {
-    const ids = new Set<string>();
-    const walk = (e: InitialEntity): void => {
-        for (const c of e.components) {
-            const modId = c.type.split(':')[0];
-            if (modId) ids.add(modId);
-        }
-        for (const child of e.children ?? []) walk(child);
-    };
-    for (const e of entities) walk(e);
-    return [...ids];
-}
-
-/** 1 mod の lock.json（ModLockEntry）を取得・検証する。取得不能なら null。 */
-async function fetchModLockEntry(modId: string): Promise<ModLockEntry | null> {
-    try {
-        const index = await fetch(`${MOD_BASE_URL}/${modId}/mod.json`, { cache: 'no-store' });
-        if (!index.ok) return null;
-        const { version } = (await index.json()) as { version?: string };
-        if (!version) return null;
-
-        const res = await fetch(`${MOD_BASE_URL}/${modId}/v${version}/lock.json`, { cache: 'no-store' });
-        if (!res.ok) return null;
-        const parsed = ModLockEntrySchema.safeParse(await res.json());
-        return parsed.success ? parsed.data : null;
-    } catch {
-        return null;
-    }
-}
-
-/**
- * ワールド定義から mod 完全性ロックを構築する。
- * 取得できなかった mod は lock から除外する（＝外部公開時、そのワールドを読む側で
- * lock-missing 拒否になる。UI 側で欠落 mod を警告するのが望ましい）。
- */
+/** ワールド定義から mod 完全性ロックを構築する（HTTP 経由で各 mod の lock.json 断片を取得）。 */
 export async function buildWorldLock(definition: WorldDefinition): Promise<ModLock> {
     const modIds = collectModIds(definition.spec.initialEntities);
-    const entries = await Promise.all(modIds.map(async (id) => [id, await fetchModLockEntry(id)] as const));
-    const mods = Object.fromEntries(entries.filter((e): e is [string, ModLockEntry] => e[1] !== null));
-    return { lockVersion: 1, mods };
+    return build(modIds, createHttpLockEntryGetter(MOD_BASE_URL));
 }

--- a/packages/frontend/src/mods/modLoader.ts
+++ b/packages/frontend/src/mods/modLoader.ts
@@ -1,17 +1,14 @@
 /**
- * modLoader — mod の「取得 + 完全性検証」層（React 非依存）。
+ * modLoader — frontend 側の薄いアダプタ。
  *
- * 責務境界:
- *  - 知識（スキーマ / lock 判定 / capability カタログ）は @ubichill/shared。
- *  - 取得（URL/CDN・fetch・crypto・lock 照合）はここ。
- *  - 状態（キャッシュ・進捗・register）は ModRegistryContext（React）。
- *  - 隔離実行（Worker 起動・実行時 enforcement）は @ubichill/sandbox。
- *
- * ここは URL と bytes を扱うが、sandbox には「検証済み workerCode + capability 天井」
- * しか渡らない。sandbox は URL/CDN/integrity を一切知らない（責務の一方向依存）。
+ * 取得・integrity・lock 照合の中核は @ubichill/loader（env非依存）に分離済み。
+ * ここは Host 固有の 2 点だけ担う:
+ *  - `VITE_MOD_CDN_URL` env から baseUrl を解決する。
+ *  - 中立 `LoadedMod` を Host の `WorkerModDefinition`（React 型）にマップする。
  */
+import { type AcquireResult, acquireMod, type LoadedMod } from '@ubichill/loader';
 import type { WorkerModDefinition } from '@ubichill/react';
-import { formatIntegrity, type LockRejectReason, type ModLock, requiresLock, resolveLockedMod } from '@ubichill/shared';
+import type { ModLock } from '@ubichill/shared';
 
 /**
  * mod のベース URL。
@@ -23,195 +20,38 @@ export const MOD_BASE_URL: string = (() => {
     return '/mods';
 })();
 
-/** ルート mod.json（最新バージョンへのポインタ）。 */
-interface ModIndex {
-    id: string;
-    name?: string;
-    version: string;
+/** loader の {@link AcquireResult} と同形（Host 側でも分岐に使う）。 */
+export type LoadResult = WorkerModDefinition | 'data-only' | 'not-found' | { rejected: string };
+
+/** 中立 LoadedMod を Host の WorkerModDefinition にマップする。 */
+function toWorkerModDefinition(m: LoadedMod): WorkerModDefinition {
+    return {
+        id: m.id,
+        name: m.name,
+        workerCode: m.workerCode,
+        capabilities: m.capabilities,
+        singleton: m.singleton,
+        canvasTargets: m.canvasTargets,
+        watchEntityTypes: m.watchEntityTypes,
+        watchScope: m.watchScope,
+        thumbnail: m.thumbnail,
+        mediaTargets: m.mediaTargets,
+        modBase: m.modBase,
+    };
 }
-
-/** versioned manifest の Component 定義（build 時の src は含まない）。 */
-interface WorkerMetaObject {
-    workerUrl?: string;
-    capabilities?: string[];
-    singleton?: boolean;
-    canvasTargets?: string[];
-    watchEntityTypes?: string[];
-    watchScope?: 'entity' | 'subtree' | 'parent' | 'world';
-    thumbnail?: string;
-    mediaTargets?: string[];
-    defaultTransform?: Record<string, unknown>;
-    dataFields?: Record<string, unknown>;
-}
-
-interface VersionedModJson {
-    id: string;
-    name?: string;
-    version: string;
-    components?: Record<string, WorkerMetaObject>;
-}
-
-/** manifest のバイト列 hash（integrity 照合用）とパース結果をまとめて保持する。 */
-interface FetchedManifest {
-    manifest: VersionedModJson;
-    /** manifest.json の生バイト列 sha256（`sha256-<base64>`）。 */
-    integrity: string;
-}
-
-// ── module スコープのキャッシュ（1 タブ内で共有）─────────────────
-const modIndexCache = new Map<string, Promise<ModIndex | null>>();
-const manifestCache = new Map<string, Promise<FetchedManifest | null>>();
-
-/**
- * ArrayBuffer を SRI 文字列 `sha256-<base64>` に変換する。
- * build 側（`Buffer.from(code,'utf-8')` の sha256 base64）と同一バイト列・同一規約で
- * 照合できるよう、必ず fetch した生バイト列を渡すこと。
- */
-async function sriOf(bytes: ArrayBuffer): Promise<string> {
-    const digest = await crypto.subtle.digest('SHA-256', bytes);
-    // spread は大きな bundle で stack を溢れさせるため Array.from(mapper) で 1 バイトずつ。
-    const binary = Array.from(new Uint8Array(digest), (b) => String.fromCharCode(b)).join('');
-    return formatIntegrity(btoa(binary));
-}
-
-function fetchModIndex(modName: string): Promise<ModIndex | null> {
-    const cached = modIndexCache.get(modName);
-    if (cached) return cached;
-    const p = fetch(`${MOD_BASE_URL}/${modName}/mod.json`, { cache: 'no-store' })
-        .then((r) => (r.ok ? (r.json() as Promise<ModIndex>) : null))
-        .catch(() => null);
-    modIndexCache.set(modName, p);
-    return p;
-}
-
-function fetchManifest(modName: string, version: string): Promise<FetchedManifest | null> {
-    const key = `${modName}@${version}`;
-    const cached = manifestCache.get(key);
-    if (cached) return cached;
-    // no-store: workerUrl のハッシュがビルド毎に変わるため古い参照を掴まない。
-    // 生バイト列を hash する必要があるため arrayBuffer で取得してから decode/parse する。
-    const p = fetch(`${MOD_BASE_URL}/${modName}/v${version}/manifest.json`, { cache: 'no-store' })
-        .then(async (r): Promise<FetchedManifest | null> => {
-            if (!r.ok) return null;
-            const bytes = await r.arrayBuffer();
-            const integrity = await sriOf(bytes);
-            const manifest = JSON.parse(new TextDecoder().decode(bytes)) as VersionedModJson;
-            return { manifest, integrity };
-        })
-        .catch(() => null);
-    manifestCache.set(key, p);
-    return p;
-}
-
-/**
- * loadVerifiedMod の戻り値。
- *  - WorkerModDefinition : ロード成功（capabilities は lock 天井 or manifest 由来）。
- *  - 'data-only'         : worker を持たない純データ Component（警告不要）。
- *  - 'not-found'         : manifest/worker 取得失敗・未宣言。
- *  - { rejected }        : lock 照合で拒否（外部 provenance）。理由付き。
- */
-export type LoadResult = WorkerModDefinition | 'data-only' | 'not-found' | { rejected: LockRejectReason };
 
 export interface LoadModOptions {
-    /** ワールドに焼かれた mod 完全性ロック（無い場合あり）。 */
     lock?: ModLock;
-    /** ワールドの provenance kind（local/github/... enforcement 分岐）。 */
     sourceKind: string;
 }
 
-/**
- * Component 型（`modId:componentName`）から検証済み WorkerModDefinition を構築する。
- *
- * lock がある mod は「固定 version」を直接取得し（最新ポインタを信頼しない）、
- * manifest / worker の生バイト列 hash を lock と照合する。外部 provenance の不一致・
- * lock 欠落は実行拒否。local は寛容（不一致でも警告続行）。capability は verified 時のみ
- * lock 天井、それ以外は manifest 由来。
- */
+/** Component 型から検証済み WorkerModDefinition を構築する（loader へ委譲）。 */
 export async function loadVerifiedMod(entityType: string, opts: LoadModOptions): Promise<LoadResult> {
-    const colonIdx = entityType.indexOf(':');
-    if (colonIdx === -1) return 'not-found';
-
-    const modName = entityType.slice(0, colonIdx);
-    const lockEntry = opts.lock?.mods[modName];
-
-    // 外部 provenance で lock 記載が無いなら、fetch する前に拒否する。
-    if (!lockEntry && requiresLock(opts.sourceKind)) return { rejected: 'lock-missing' };
-
-    // version は lock を最優先で固定（無ければ最新ポインタ）。
-    const version = lockEntry?.version ?? (await fetchModIndex(modName))?.version;
-    if (!version) return 'not-found';
-
-    const fetched = await fetchManifest(modName, version);
-    const entry = fetched?.manifest.components?.[entityType];
-    if (!fetched || !entry) return 'not-found';
-    if (!entry.workerUrl) return 'data-only';
-
-    const versionedBase = `${MOD_BASE_URL}/${modName}/v${version}`;
-    // workerUrl は lock を優先（固定パス）。無ければ manifest 由来。
-    const relWorkerUrl = lockEntry?.components[entityType]?.workerUrl ?? entry.workerUrl;
-    const workerUrl = `${versionedBase}/${relWorkerUrl.replace(/^\.\//, '')}`;
-
-    const fetchedWorker = await fetchWorkerBytes(workerUrl, entityType);
-    if (!fetchedWorker) return 'not-found';
-
-    const verdict = resolveLockedMod({
-        entityType,
-        lockEntry,
-        workerIntegrity: fetchedWorker.integrity,
-        manifestIntegrity: fetched.integrity,
+    const result: AcquireResult = await acquireMod(entityType, {
+        baseUrl: MOD_BASE_URL,
+        lock: opts.lock,
         sourceKind: opts.sourceKind,
     });
-
-    if (verdict.status === 'rejected') {
-        // 外部は拒否。local は「壊れているかも」警告のみで従来通り続行する。
-        if (requiresLock(opts.sourceKind)) return { rejected: verdict.reason };
-        console.warn(`[modLoader] lock 不一致 (${verdict.reason}) だが local のため続行: ${entityType}`);
-    }
-
-    // capability 天井: verified は lock 由来のみ、それ以外は manifest 由来（従来挙動）。
-    const capabilities = verdict.status === 'verified' ? [...verdict.capabilities] : entry.capabilities;
-
-    const def: WorkerModDefinition = {
-        id: entityType,
-        name: `${fetched.manifest.name ?? modName} - ${entityType.slice(colonIdx + 1)}`,
-        workerCode: new TextDecoder().decode(fetchedWorker.bytes),
-        capabilities,
-        singleton: entry.singleton,
-        canvasTargets: entry.canvasTargets,
-        watchEntityTypes: entry.watchEntityTypes,
-        watchScope: entry.watchScope ?? 'subtree',
-        thumbnail: entry.thumbnail,
-        mediaTargets: entry.mediaTargets,
-        modBase: versionedBase,
-    };
-    return def;
-}
-
-interface FetchedWorker {
-    bytes: ArrayBuffer;
-    integrity: string;
-}
-
-/** worker の生バイト列を取得し integrity を計算する。非 JS content-type は拒否。 */
-async function fetchWorkerBytes(workerUrl: string, entityType: string): Promise<FetchedWorker | null> {
-    try {
-        const res = await fetch(workerUrl);
-        if (!res.ok) return null;
-        // Vite の SPA fallback で index.html が返ると sandbox の new Function() が壊れるため拒否。
-        const ct = res.headers.get('content-type') ?? '';
-        if (!ct.includes('javascript') && !ct.includes('text/plain') && ct !== '') {
-            console.warn(`[modLoader] worker fetch が非 JS content-type "${ct}" を返した: ${entityType}`);
-            return null;
-        }
-        const bytes = await res.arrayBuffer();
-        return { bytes, integrity: await sriOf(bytes) };
-    } catch {
-        return null;
-    }
-}
-
-/** テスト / インスタンス離脱時のキャッシュリセット。 */
-export function resetModLoaderCaches(): void {
-    modIndexCache.clear();
-    manifestCache.clear();
+    if (typeof result === 'object' && 'workerCode' in result) return toWorkerModDefinition(result);
+    return result;
 }

--- a/packages/frontend/src/mods/modLoader.ts
+++ b/packages/frontend/src/mods/modLoader.ts
@@ -1,0 +1,217 @@
+/**
+ * modLoader — mod の「取得 + 完全性検証」層（React 非依存）。
+ *
+ * 責務境界:
+ *  - 知識（スキーマ / lock 判定 / capability カタログ）は @ubichill/shared。
+ *  - 取得（URL/CDN・fetch・crypto・lock 照合）はここ。
+ *  - 状態（キャッシュ・進捗・register）は ModRegistryContext（React）。
+ *  - 隔離実行（Worker 起動・実行時 enforcement）は @ubichill/sandbox。
+ *
+ * ここは URL と bytes を扱うが、sandbox には「検証済み workerCode + capability 天井」
+ * しか渡らない。sandbox は URL/CDN/integrity を一切知らない（責務の一方向依存）。
+ */
+import type { WorkerModDefinition } from '@ubichill/react';
+import { formatIntegrity, type LockRejectReason, type ModLock, requiresLock, resolveLockedMod } from '@ubichill/shared';
+
+/**
+ * mod のベース URL。
+ * VITE_MOD_CDN_URL があれば外部 CDN / GitHub Pages、無ければ自ホストの /mods。
+ */
+export const MOD_BASE_URL: string = (() => {
+    const envUrl = import.meta.env.VITE_MOD_CDN_URL as string | undefined;
+    if (envUrl) return envUrl.replace(/\/$/, '');
+    return '/mods';
+})();
+
+/** ルート mod.json（最新バージョンへのポインタ）。 */
+interface ModIndex {
+    id: string;
+    name?: string;
+    version: string;
+}
+
+/** versioned manifest の Component 定義（build 時の src は含まない）。 */
+interface WorkerMetaObject {
+    workerUrl?: string;
+    capabilities?: string[];
+    singleton?: boolean;
+    canvasTargets?: string[];
+    watchEntityTypes?: string[];
+    watchScope?: 'entity' | 'subtree' | 'parent' | 'world';
+    thumbnail?: string;
+    mediaTargets?: string[];
+    defaultTransform?: Record<string, unknown>;
+    dataFields?: Record<string, unknown>;
+}
+
+interface VersionedModJson {
+    id: string;
+    name?: string;
+    version: string;
+    components?: Record<string, WorkerMetaObject>;
+}
+
+/** manifest のバイト列 hash（integrity 照合用）とパース結果をまとめて保持する。 */
+interface FetchedManifest {
+    manifest: VersionedModJson;
+    /** manifest.json の生バイト列 sha256（`sha256-<base64>`）。 */
+    integrity: string;
+}
+
+// ── module スコープのキャッシュ（1 タブ内で共有）─────────────────
+const modIndexCache = new Map<string, Promise<ModIndex | null>>();
+const manifestCache = new Map<string, Promise<FetchedManifest | null>>();
+
+/**
+ * ArrayBuffer を SRI 文字列 `sha256-<base64>` に変換する。
+ * build 側（`Buffer.from(code,'utf-8')` の sha256 base64）と同一バイト列・同一規約で
+ * 照合できるよう、必ず fetch した生バイト列を渡すこと。
+ */
+async function sriOf(bytes: ArrayBuffer): Promise<string> {
+    const digest = await crypto.subtle.digest('SHA-256', bytes);
+    // spread は大きな bundle で stack を溢れさせるため Array.from(mapper) で 1 バイトずつ。
+    const binary = Array.from(new Uint8Array(digest), (b) => String.fromCharCode(b)).join('');
+    return formatIntegrity(btoa(binary));
+}
+
+function fetchModIndex(modName: string): Promise<ModIndex | null> {
+    const cached = modIndexCache.get(modName);
+    if (cached) return cached;
+    const p = fetch(`${MOD_BASE_URL}/${modName}/mod.json`, { cache: 'no-store' })
+        .then((r) => (r.ok ? (r.json() as Promise<ModIndex>) : null))
+        .catch(() => null);
+    modIndexCache.set(modName, p);
+    return p;
+}
+
+function fetchManifest(modName: string, version: string): Promise<FetchedManifest | null> {
+    const key = `${modName}@${version}`;
+    const cached = manifestCache.get(key);
+    if (cached) return cached;
+    // no-store: workerUrl のハッシュがビルド毎に変わるため古い参照を掴まない。
+    // 生バイト列を hash する必要があるため arrayBuffer で取得してから decode/parse する。
+    const p = fetch(`${MOD_BASE_URL}/${modName}/v${version}/manifest.json`, { cache: 'no-store' })
+        .then(async (r): Promise<FetchedManifest | null> => {
+            if (!r.ok) return null;
+            const bytes = await r.arrayBuffer();
+            const integrity = await sriOf(bytes);
+            const manifest = JSON.parse(new TextDecoder().decode(bytes)) as VersionedModJson;
+            return { manifest, integrity };
+        })
+        .catch(() => null);
+    manifestCache.set(key, p);
+    return p;
+}
+
+/**
+ * loadVerifiedMod の戻り値。
+ *  - WorkerModDefinition : ロード成功（capabilities は lock 天井 or manifest 由来）。
+ *  - 'data-only'         : worker を持たない純データ Component（警告不要）。
+ *  - 'not-found'         : manifest/worker 取得失敗・未宣言。
+ *  - { rejected }        : lock 照合で拒否（外部 provenance）。理由付き。
+ */
+export type LoadResult = WorkerModDefinition | 'data-only' | 'not-found' | { rejected: LockRejectReason };
+
+export interface LoadModOptions {
+    /** ワールドに焼かれた mod 完全性ロック（無い場合あり）。 */
+    lock?: ModLock;
+    /** ワールドの provenance kind（local/github/... enforcement 分岐）。 */
+    sourceKind: string;
+}
+
+/**
+ * Component 型（`modId:componentName`）から検証済み WorkerModDefinition を構築する。
+ *
+ * lock がある mod は「固定 version」を直接取得し（最新ポインタを信頼しない）、
+ * manifest / worker の生バイト列 hash を lock と照合する。外部 provenance の不一致・
+ * lock 欠落は実行拒否。local は寛容（不一致でも警告続行）。capability は verified 時のみ
+ * lock 天井、それ以外は manifest 由来。
+ */
+export async function loadVerifiedMod(entityType: string, opts: LoadModOptions): Promise<LoadResult> {
+    const colonIdx = entityType.indexOf(':');
+    if (colonIdx === -1) return 'not-found';
+
+    const modName = entityType.slice(0, colonIdx);
+    const lockEntry = opts.lock?.mods[modName];
+
+    // 外部 provenance で lock 記載が無いなら、fetch する前に拒否する。
+    if (!lockEntry && requiresLock(opts.sourceKind)) return { rejected: 'lock-missing' };
+
+    // version は lock を最優先で固定（無ければ最新ポインタ）。
+    const version = lockEntry?.version ?? (await fetchModIndex(modName))?.version;
+    if (!version) return 'not-found';
+
+    const fetched = await fetchManifest(modName, version);
+    const entry = fetched?.manifest.components?.[entityType];
+    if (!fetched || !entry) return 'not-found';
+    if (!entry.workerUrl) return 'data-only';
+
+    const versionedBase = `${MOD_BASE_URL}/${modName}/v${version}`;
+    // workerUrl は lock を優先（固定パス）。無ければ manifest 由来。
+    const relWorkerUrl = lockEntry?.components[entityType]?.workerUrl ?? entry.workerUrl;
+    const workerUrl = `${versionedBase}/${relWorkerUrl.replace(/^\.\//, '')}`;
+
+    const fetchedWorker = await fetchWorkerBytes(workerUrl, entityType);
+    if (!fetchedWorker) return 'not-found';
+
+    const verdict = resolveLockedMod({
+        entityType,
+        lockEntry,
+        workerIntegrity: fetchedWorker.integrity,
+        manifestIntegrity: fetched.integrity,
+        sourceKind: opts.sourceKind,
+    });
+
+    if (verdict.status === 'rejected') {
+        // 外部は拒否。local は「壊れているかも」警告のみで従来通り続行する。
+        if (requiresLock(opts.sourceKind)) return { rejected: verdict.reason };
+        console.warn(`[modLoader] lock 不一致 (${verdict.reason}) だが local のため続行: ${entityType}`);
+    }
+
+    // capability 天井: verified は lock 由来のみ、それ以外は manifest 由来（従来挙動）。
+    const capabilities = verdict.status === 'verified' ? [...verdict.capabilities] : entry.capabilities;
+
+    const def: WorkerModDefinition = {
+        id: entityType,
+        name: `${fetched.manifest.name ?? modName} - ${entityType.slice(colonIdx + 1)}`,
+        workerCode: new TextDecoder().decode(fetchedWorker.bytes),
+        capabilities,
+        singleton: entry.singleton,
+        canvasTargets: entry.canvasTargets,
+        watchEntityTypes: entry.watchEntityTypes,
+        watchScope: entry.watchScope ?? 'subtree',
+        thumbnail: entry.thumbnail,
+        mediaTargets: entry.mediaTargets,
+        modBase: versionedBase,
+    };
+    return def;
+}
+
+interface FetchedWorker {
+    bytes: ArrayBuffer;
+    integrity: string;
+}
+
+/** worker の生バイト列を取得し integrity を計算する。非 JS content-type は拒否。 */
+async function fetchWorkerBytes(workerUrl: string, entityType: string): Promise<FetchedWorker | null> {
+    try {
+        const res = await fetch(workerUrl);
+        if (!res.ok) return null;
+        // Vite の SPA fallback で index.html が返ると sandbox の new Function() が壊れるため拒否。
+        const ct = res.headers.get('content-type') ?? '';
+        if (!ct.includes('javascript') && !ct.includes('text/plain') && ct !== '') {
+            console.warn(`[modLoader] worker fetch が非 JS content-type "${ct}" を返した: ${entityType}`);
+            return null;
+        }
+        const bytes = await res.arrayBuffer();
+        return { bytes, integrity: await sriOf(bytes) };
+    } catch {
+        return null;
+    }
+}
+
+/** テスト / インスタンス離脱時のキャッシュリセット。 */
+export function resetModLoaderCaches(): void {
+    modIndexCache.clear();
+    manifestCache.clear();
+}

--- a/packages/frontend/src/pages/InstancePage.tsx
+++ b/packages/frontend/src/pages/InstancePage.tsx
@@ -16,7 +16,7 @@ export function InstancePage() {
     const { data: session, isPending } = useSession();
 
     const { isConnected, error, currentUser, joinWorld, leaveWorld } = useSocket();
-    const { resetWorld } = useWorld();
+    const { resetWorld, modLock, worldSourceKind } = useWorld();
 
     const joinedIdRef = useRef<string | null>(null);
     const leaveWorldRef = useRef(leaveWorld);
@@ -145,7 +145,7 @@ export function InstancePage() {
             )}
             {!loading.failed && currentUser != null && (
                 <main>
-                    <ModRegistryProvider key={id} onStatusChange={setMods}>
+                    <ModRegistryProvider key={id} onStatusChange={setMods} lock={modLock} sourceKind={worldSourceKind}>
                         <WorkerLoadingProvider onStatusChange={setWorkers}>
                             <InstanceRenderer />
                         </WorkerLoadingProvider>

--- a/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
@@ -3,6 +3,7 @@ import { useCallback, useState } from 'react';
 import { useNavigate } from 'react-router';
 import yaml from 'yaml';
 import { API_BASE } from '@/lib/api';
+import { buildWorldLock } from '@/mods/buildWorldLock';
 
 interface UseWorldEditorApiArgs {
     isEdit: boolean;
@@ -26,7 +27,11 @@ export function useWorldEditorApi({ isEdit, worldId, definition, onSavedYamlChan
         setSaving(true);
         onError('');
         try {
-            const text = yaml.stringify(definition);
+            // 保存時に mod 完全性ロックを焼き込む。外部公開時、そのワールドを読む側は
+            // この hash と照合して差し替え mod の実行を拒否できる（配布者を信頼しない）。
+            const lock = await buildWorldLock(definition);
+            const locked: WorldDefinition = { ...definition, spec: { ...definition.spec, lock } };
+            const text = yaml.stringify(locked);
             const url =
                 isEdit && worldId ? `${API_BASE}/api/v1/worlds/${worldId}/yaml` : `${API_BASE}/api/v1/worlds/yaml`;
             const method = isEdit ? 'PUT' : 'POST';

--- a/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
@@ -27,11 +27,12 @@ export function useWorldEditorApi({ isEdit, worldId, definition, onSavedYamlChan
         setSaving(true);
         onError('');
         try {
-            // 保存時に mod 完全性ロックを焼き込む。外部公開時、そのワールドを読む側は
-            // この hash と照合して差し替え mod の実行を拒否できる（配布者を信頼しない）。
+            // 保存時に mod 完全性ロックを計算する。lock は人間が書く YAML には埋めず、
+            // body の別フィールドで送ってサーバ側の別カラムに保存する（YAML はクリーンに保つ）。
+            // 外部公開時、そのワールドを読む側は兄弟エンドポイントの lock と hash 照合して
+            // 差し替え mod の実行を拒否できる（配布者を信頼しない）。
             const lock = await buildWorldLock(definition);
-            const locked: WorldDefinition = { ...definition, spec: { ...definition.spec, lock } };
-            const text = yaml.stringify(locked);
+            const text = yaml.stringify(definition);
             const url =
                 isEdit && worldId ? `${API_BASE}/api/v1/worlds/${worldId}/yaml` : `${API_BASE}/api/v1/worlds/yaml`;
             const method = isEdit ? 'PUT' : 'POST';
@@ -39,7 +40,7 @@ export function useWorldEditorApi({ isEdit, worldId, definition, onSavedYamlChan
                 method,
                 headers: { 'Content-Type': 'application/json' },
                 credentials: 'include',
-                body: JSON.stringify({ yaml: text }),
+                body: JSON.stringify({ yaml: text, lock }),
             });
             if (!res.ok) {
                 const data = (await res.json().catch(() => ({}))) as { error?: string };

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -6,9 +6,7 @@
     "main": "src/index.ts",
     "types": "src/index.ts",
     "dependencies": {
-        "@ubichill/shared": "workspace:*"
-    },
-    "devDependencies": {
+        "@ubichill/shared": "workspace:*",
         "yaml": "^2.5.0"
     }
 }

--- a/packages/loader/package.json
+++ b/packages/loader/package.json
@@ -1,0 +1,14 @@
+{
+    "name": "@ubichill/loader",
+    "version": "1.0.0",
+    "description": "mod の取得・完全性検証・ロック構築。browser+Node 両対応・React/DOM 非依存。frontend と CLI が共有する。",
+    "sideEffects": false,
+    "main": "src/index.ts",
+    "types": "src/index.ts",
+    "dependencies": {
+        "@ubichill/shared": "workspace:*"
+    },
+    "devDependencies": {
+        "yaml": "^2.5.0"
+    }
+}

--- a/packages/loader/src/acquireMod.test.ts
+++ b/packages/loader/src/acquireMod.test.ts
@@ -140,6 +140,21 @@ describe('acquireMod', () => {
         expect(r).toBe('data-only');
     });
 
+    it('lockEntry はあるが対象 component が lock に無い + 外部 → lock-missing 拒否', async () => {
+        // mod（pen）の lock はあるが components が空＝この entity の hash が固定されていない。
+        // manifest には entity が存在するので取得は進むが、lock 未記載として拒否されるべき。
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE,
+            lock: {
+                lockVersion: 1,
+                mods: { [MOD]: { id: MOD, version: VER, manifestIntegrity: sri(manifestJson), components: {} } },
+            },
+            sourceKind: 'github',
+            fetchImpl: fakeFetch(goodRoutes()),
+        });
+        expect(r).toEqual({ rejected: 'lock-missing' });
+    });
+
     it('コロンを含まない entityType は not-found', async () => {
         const r = await acquireMod('nocolon', { baseUrl: BASE, sourceKind: 'local', fetchImpl: fakeFetch({}) });
         expect(r).toBe('not-found');

--- a/packages/loader/src/acquireMod.test.ts
+++ b/packages/loader/src/acquireMod.test.ts
@@ -1,0 +1,147 @@
+import { createHash } from 'node:crypto';
+import type { ModLock } from '@ubichill/shared';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { acquireMod, resetAcquireCaches } from './acquireMod';
+import type { FetchLike, FetchLikeResponse } from './types';
+
+const BASE = 'https://cdn.test/mods';
+const MOD = 'pen';
+const VER = '2.0.0';
+const TYPE = 'pen:canvas';
+const WORKER_CODE = 'globalThis.onmessage = () => {};';
+const WORKER_URL = './canvas/index.abc.js';
+
+/** build-workers と同一規約の SRI（テストで lock/期待値を作る用）。 */
+function sri(text: string): string {
+    return `sha256-${createHash('sha256').update(Buffer.from(text, 'utf-8')).digest('base64')}`;
+}
+
+const manifestJson = JSON.stringify({
+    id: MOD,
+    name: 'Pen',
+    version: VER,
+    components: { [TYPE]: { workerUrl: WORKER_URL, capabilities: ['scene:read'] } },
+});
+
+/** URL→レスポンス本体をひく最小 fetch フェイク。 */
+function fakeFetch(routes: Record<string, { body: string; contentType?: string; ok?: boolean }>): FetchLike {
+    return async (input): Promise<FetchLikeResponse> => {
+        const hit = routes[input];
+        const body = hit?.body ?? '';
+        return {
+            ok: hit ? (hit.ok ?? true) : false,
+            headers: { get: (n) => (n.toLowerCase() === 'content-type' ? (hit?.contentType ?? '') : null) },
+            json: async () => JSON.parse(body),
+            text: async () => body,
+            arrayBuffer: async () => new TextEncoder().encode(body).buffer,
+        };
+    };
+}
+
+const workerUrlAbs = `${BASE}/${MOD}/v${VER}/canvas/index.abc.js`;
+const manifestUrlAbs = `${BASE}/${MOD}/v${VER}/manifest.json`;
+
+/** 正規ルート（manifest + worker）。worker の content-type は javascript。 */
+function goodRoutes(workerCode = WORKER_CODE) {
+    return {
+        [manifestUrlAbs]: { body: manifestJson },
+        [workerUrlAbs]: { body: workerCode, contentType: 'text/javascript' },
+    };
+}
+
+/** lock（capability 天井 = scene:read のみ。manifest と同じ hash）。 */
+function lock(workerCode = WORKER_CODE): ModLock {
+    return {
+        lockVersion: 1,
+        mods: {
+            [MOD]: {
+                id: MOD,
+                version: VER,
+                manifestIntegrity: sri(manifestJson),
+                components: {
+                    [TYPE]: { workerUrl: WORKER_URL, integrity: sri(workerCode), capabilities: ['scene:read'] },
+                },
+            },
+        },
+    };
+}
+
+beforeEach(() => resetAcquireCaches());
+
+describe('acquireMod', () => {
+    it('正規バイト列 + 外部 provenance → verified、capabilities は lock 天井', async () => {
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE,
+            lock: lock(),
+            sourceKind: 'github',
+            fetchImpl: fakeFetch(goodRoutes()),
+        });
+        expect(typeof r === 'object' && 'workerCode' in r).toBe(true);
+        if (typeof r === 'object' && 'workerCode' in r) {
+            expect(r.workerCode).toBe(WORKER_CODE);
+            expect(r.capabilities).toEqual(['scene:read']);
+            expect(r.modBase).toBe(`${BASE}/${MOD}/v${VER}`);
+        }
+    });
+
+    it('worker が差し替えられている（hash 不一致）+ 外部 → integrity-mismatch で拒否', async () => {
+        const tampered = `${WORKER_CODE} /* injected */`;
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE,
+            lock: lock(), // lock は元コードの hash
+            sourceKind: 'remote-instance',
+            fetchImpl: fakeFetch(goodRoutes(tampered)), // 配信は改竄コード
+        });
+        expect(r).toEqual({ rejected: 'integrity-mismatch' });
+    });
+
+    it('外部 provenance で lock 記載が無い → fetch せず lock-missing 拒否', async () => {
+        let called = false;
+        const spy: FetchLike = async (input) => {
+            called = true;
+            return fakeFetch(goodRoutes())(input);
+        };
+        const r = await acquireMod(TYPE, { baseUrl: BASE, sourceKind: 'url', fetchImpl: spy });
+        expect(r).toEqual({ rejected: 'lock-missing' });
+        expect(called).toBe(false); // ネットワークに触れない
+    });
+
+    it('local は lock 不一致でも警告続行し、capability は manifest 由来', async () => {
+        const tampered = `${WORKER_CODE} /* local edit */`;
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE,
+            lock: lock(), // 元 hash
+            sourceKind: 'local',
+            fetchImpl: fakeFetch(goodRoutes(tampered)),
+        });
+        expect(typeof r === 'object' && 'workerCode' in r).toBe(true);
+        if (typeof r === 'object' && 'workerCode' in r) {
+            expect(r.workerCode).toBe(tampered);
+            // verified ではないので manifest の capabilities（scene:read）を採用
+            expect(r.capabilities).toEqual(['scene:read']);
+        }
+    });
+
+    it('workerUrl の無い Component は data-only', async () => {
+        const dataOnlyManifest = JSON.stringify({
+            id: MOD,
+            version: VER,
+            components: { [TYPE]: { capabilities: [] } },
+        });
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE,
+            lock: {
+                lockVersion: 1,
+                mods: { [MOD]: { id: MOD, version: VER, manifestIntegrity: sri(dataOnlyManifest), components: {} } },
+            },
+            sourceKind: 'local',
+            fetchImpl: fakeFetch({ [manifestUrlAbs]: { body: dataOnlyManifest } }),
+        });
+        expect(r).toBe('data-only');
+    });
+
+    it('コロンを含まない entityType は not-found', async () => {
+        const r = await acquireMod('nocolon', { baseUrl: BASE, sourceKind: 'local', fetchImpl: fakeFetch({}) });
+        expect(r).toBe('not-found');
+    });
+});

--- a/packages/loader/src/acquireMod.ts
+++ b/packages/loader/src/acquireMod.ts
@@ -53,6 +53,12 @@ export interface AcquireModOptions {
 const defaultFetch: FetchLike = (input, init) => fetch(input, init as RequestInit) as unknown as ReturnType<FetchLike>;
 
 // ── module スコープのキャッシュ（baseUrl+mod で分離）─────────────
+// インスタンス跨ぎで意図的に共有する（同じ mod を複数ワールドで使い回すため）。TTL は持たない:
+//  - manifest は `baseUrl::mod@version` キー。version が変われば別キー＝新規取得になる。
+//  - HTTP レベルの陳腐化は `{ cache: 'no-store' }` で迂回する。
+//  - worker バイト列はキャッシュしない（毎回取得し hash 照合する）。
+// 開発中に同一 version のまま mod を作り直した場合のみ古い index/manifest を掴むので、
+// その時は resetAcquireCaches() で明示的にクリアする。
 const modIndexCache = new Map<string, Promise<VersionedModJson | null>>();
 const manifestCache = new Map<string, Promise<FetchedManifest | null>>();
 
@@ -101,7 +107,9 @@ async function fetchWorkerBytes(workerUrl: string, entityType: string, f: FetchL
     try {
         const res = await f(workerUrl);
         if (!res.ok) return null;
-        // SPA fallback で index.html が返ると sandbox の new Function() が壊れるため拒否。
+        // 許可するのは javascript / text-plain / 空 のみ。それ以外（SPA fallback の text/html や
+        // 誤って返る application/json 等）は拒否する。HTML/JSON が worker コードに混ざると
+        // sandbox の new Function() が構文エラーで死ぬため、ここで弾く。
         const ct = res.headers.get('content-type') ?? '';
         if (!ct.includes('javascript') && !ct.includes('text/plain') && ct !== '') {
             console.warn(`[loader] worker fetch が非 JS content-type "${ct}" を返した: ${entityType}`);

--- a/packages/loader/src/acquireMod.ts
+++ b/packages/loader/src/acquireMod.ts
@@ -1,0 +1,192 @@
+/**
+ * acquireMod — mod の「取得 + 完全性検証」（env非依存の中核）。
+ *
+ * 責務境界:
+ *  - 知識（スキーマ / lock 判定 / capability カタログ）は @ubichill/shared。
+ *  - 取得（fetch・crypto・lock 照合）はここ。baseUrl / fetch は注入する。
+ *  - 状態（React context）や URL/CDN の env 解決は呼び出し側（frontend アダプタ）。
+ *
+ * 返す LoadedMod は React/DOM 非依存の中立表現。Host が WorkerModDefinition にマップする。
+ */
+import { type ModLock, requiresLock, resolveLockedMod } from '@ubichill/shared';
+import { sriOf } from './integrity';
+import type { AcquireResult, FetchLike, LoadedMod } from './types';
+
+/** versioned manifest の Component 定義（build 時の src は含まない）。 */
+interface WorkerMetaObject {
+    workerUrl?: string;
+    capabilities?: string[];
+    singleton?: boolean;
+    canvasTargets?: string[];
+    watchEntityTypes?: string[];
+    watchScope?: 'entity' | 'subtree' | 'parent' | 'world';
+    thumbnail?: string;
+    mediaTargets?: string[];
+    defaultTransform?: Record<string, unknown>;
+    dataFields?: Record<string, unknown>;
+}
+
+interface VersionedModJson {
+    id: string;
+    name?: string;
+    version: string;
+    components?: Record<string, WorkerMetaObject>;
+}
+
+/** manifest のバイト列 hash（integrity 照合用）とパース結果。 */
+interface FetchedManifest {
+    manifest: VersionedModJson;
+    integrity: string;
+}
+
+export interface AcquireModOptions {
+    /** mod のベース URL（例: `/mods` or 外部 CDN）。末尾スラッシュなし。 */
+    baseUrl: string;
+    /** ワールドに焼かれた mod 完全性ロック（無い場合あり）。 */
+    lock?: ModLock;
+    /** ワールドの provenance kind（local/github/... enforcement 分岐）。 */
+    sourceKind: string;
+    /** 注入 fetch（既定: globalThis.fetch）。テスト・Node 実行で差し替える。 */
+    fetchImpl?: FetchLike;
+}
+
+const defaultFetch: FetchLike = (input, init) => fetch(input, init as RequestInit) as unknown as ReturnType<FetchLike>;
+
+// ── module スコープのキャッシュ（baseUrl+mod で分離）─────────────
+const modIndexCache = new Map<string, Promise<VersionedModJson | null>>();
+const manifestCache = new Map<string, Promise<FetchedManifest | null>>();
+
+function fetchModIndex(baseUrl: string, modName: string, f: FetchLike): Promise<VersionedModJson | null> {
+    const key = `${baseUrl}::${modName}`;
+    const cached = modIndexCache.get(key);
+    if (cached) return cached;
+    const p = f(`${baseUrl}/${modName}/mod.json`, { cache: 'no-store' })
+        .then((r) => (r.ok ? (r.json() as Promise<VersionedModJson>) : null))
+        .catch(() => null);
+    modIndexCache.set(key, p);
+    return p;
+}
+
+function fetchManifest(
+    baseUrl: string,
+    modName: string,
+    version: string,
+    f: FetchLike,
+): Promise<FetchedManifest | null> {
+    const key = `${baseUrl}::${modName}@${version}`;
+    const cached = manifestCache.get(key);
+    if (cached) return cached;
+    // no-store: workerUrl のハッシュがビルド毎に変わるため古い参照を掴まない。
+    // 生バイト列を hash する必要があるため arrayBuffer で取得してから decode/parse する。
+    const p = f(`${baseUrl}/${modName}/v${version}/manifest.json`, { cache: 'no-store' })
+        .then(async (r): Promise<FetchedManifest | null> => {
+            if (!r.ok) return null;
+            const bytes = await r.arrayBuffer();
+            const integrity = await sriOf(bytes);
+            const manifest = JSON.parse(new TextDecoder().decode(bytes)) as VersionedModJson;
+            return { manifest, integrity };
+        })
+        .catch(() => null);
+    manifestCache.set(key, p);
+    return p;
+}
+
+interface FetchedWorker {
+    bytes: ArrayBuffer;
+    integrity: string;
+}
+
+/** worker の生バイト列を取得し integrity を計算する。非 JS content-type は拒否。 */
+async function fetchWorkerBytes(workerUrl: string, entityType: string, f: FetchLike): Promise<FetchedWorker | null> {
+    try {
+        const res = await f(workerUrl);
+        if (!res.ok) return null;
+        // SPA fallback で index.html が返ると sandbox の new Function() が壊れるため拒否。
+        const ct = res.headers.get('content-type') ?? '';
+        if (!ct.includes('javascript') && !ct.includes('text/plain') && ct !== '') {
+            console.warn(`[loader] worker fetch が非 JS content-type "${ct}" を返した: ${entityType}`);
+            return null;
+        }
+        const bytes = await res.arrayBuffer();
+        return { bytes, integrity: await sriOf(bytes) };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Component 型（`modId:componentName`）から検証済み {@link LoadedMod} を構築する。
+ *
+ * lock がある mod は「固定 version」を直接取得し（最新ポインタを信頼しない）、
+ * manifest / worker の生バイト列 hash を lock と照合する。外部 provenance の不一致・
+ * lock 欠落は実行拒否。local は寛容（不一致でも警告続行）。capability は verified 時のみ
+ * lock 天井、それ以外は manifest 由来。
+ */
+export async function acquireMod(entityType: string, opts: AcquireModOptions): Promise<AcquireResult> {
+    const { baseUrl, lock, sourceKind } = opts;
+    const f = opts.fetchImpl ?? defaultFetch;
+
+    const colonIdx = entityType.indexOf(':');
+    if (colonIdx === -1) return 'not-found';
+
+    const modName = entityType.slice(0, colonIdx);
+    const lockEntry = lock?.mods[modName];
+
+    // 外部 provenance で lock 記載が無いなら、fetch する前に拒否する。
+    if (!lockEntry && requiresLock(sourceKind)) return { rejected: 'lock-missing' };
+
+    // version は lock を最優先で固定（無ければ最新ポインタ）。
+    const version = lockEntry?.version ?? (await fetchModIndex(baseUrl, modName, f))?.version;
+    if (!version) return 'not-found';
+
+    const fetched = await fetchManifest(baseUrl, modName, version, f);
+    const entry = fetched?.manifest.components?.[entityType];
+    if (!fetched || !entry) return 'not-found';
+    if (!entry.workerUrl) return 'data-only';
+
+    const versionedBase = `${baseUrl}/${modName}/v${version}`;
+    // workerUrl は lock を優先（固定パス）。無ければ manifest 由来。
+    const relWorkerUrl = lockEntry?.components[entityType]?.workerUrl ?? entry.workerUrl;
+    const workerUrl = `${versionedBase}/${relWorkerUrl.replace(/^\.\//, '')}`;
+
+    const fetchedWorker = await fetchWorkerBytes(workerUrl, entityType, f);
+    if (!fetchedWorker) return 'not-found';
+
+    const verdict = resolveLockedMod({
+        entityType,
+        lockEntry,
+        workerIntegrity: fetchedWorker.integrity,
+        manifestIntegrity: fetched.integrity,
+        sourceKind,
+    });
+
+    if (verdict.status === 'rejected') {
+        // 外部は拒否。local は「壊れているかも」警告のみで従来通り続行する。
+        if (requiresLock(sourceKind)) return { rejected: verdict.reason };
+        console.warn(`[loader] lock 不一致 (${verdict.reason}) だが local のため続行: ${entityType}`);
+    }
+
+    // capability 天井: verified は lock 由来のみ、それ以外は manifest 由来（従来挙動）。
+    const capabilities = verdict.status === 'verified' ? [...verdict.capabilities] : entry.capabilities;
+
+    const loaded: LoadedMod = {
+        id: entityType,
+        name: `${fetched.manifest.name ?? modName} - ${entityType.slice(colonIdx + 1)}`,
+        workerCode: new TextDecoder().decode(fetchedWorker.bytes),
+        capabilities,
+        modBase: versionedBase,
+        watchScope: entry.watchScope ?? 'subtree',
+        watchEntityTypes: entry.watchEntityTypes,
+        canvasTargets: entry.canvasTargets,
+        mediaTargets: entry.mediaTargets,
+        singleton: entry.singleton,
+        thumbnail: entry.thumbnail,
+    };
+    return loaded;
+}
+
+/** テスト / インスタンス離脱時のキャッシュリセット。 */
+export function resetAcquireCaches(): void {
+    modIndexCache.clear();
+    manifestCache.clear();
+}

--- a/packages/loader/src/buildWorldLock.test.ts
+++ b/packages/loader/src/buildWorldLock.test.ts
@@ -1,0 +1,52 @@
+import type { InitialEntity, ModLockEntry } from '@ubichill/shared';
+import { describe, expect, it } from 'vitest';
+import { buildWorldLock, collectModIds } from './buildWorldLock';
+
+/** テスト用 Entity（transform は最小）。 */
+function entity(id: string, types: string[], children: InitialEntity[] = []): InitialEntity {
+    return {
+        id,
+        transform: { x: 0, y: 0, z: 0, scale: 1, rotation: 0 },
+        components: types.map((type) => ({ type, data: {} })),
+        tags: [],
+        children,
+    };
+}
+
+function lockEntry(id: string): ModLockEntry {
+    return { id, version: '1.0.0', manifestIntegrity: 'sha256-M', components: {} };
+}
+
+describe('collectModIds', () => {
+    it('子孫を含めて modId を重複なく集める', () => {
+        const tree = [
+            entity('a', ['pen:pen', 'pen:tray'], [entity('b', ['video-player:screen'])]),
+            entity('c', ['pen:canvas']),
+        ];
+        expect(collectModIds(tree).sort()).toEqual(['pen', 'video-player']);
+    });
+
+    it('コロンを含まない不正 type は modId 側（先頭）を拾う（防御的）', () => {
+        // ComponentType はスキーマ上 "mod:name" 形式だが、split 実装の堅牢性を確認。
+        expect(collectModIds([entity('a', ['solo'])])).toEqual(['solo']);
+    });
+
+    it('空ツリーは空配列', () => {
+        expect(collectModIds([])).toEqual([]);
+    });
+});
+
+describe('buildWorldLock', () => {
+    it('取得できた mod だけを lock.mods に載せ、取得不能は除外する', async () => {
+        const getter = async (id: string) => (id === 'pen' ? lockEntry('pen') : null);
+        const lock = await buildWorldLock(['pen', 'ghost'], getter);
+        expect(lock.lockVersion).toBe(1);
+        expect(Object.keys(lock.mods)).toEqual(['pen']);
+        expect(lock.mods.pen.id).toBe('pen');
+    });
+
+    it('全 mod が取得不能なら空 lock（外部公開時は読む側で lock-missing 拒否）', async () => {
+        const lock = await buildWorldLock(['a', 'b'], async () => null);
+        expect(lock.mods).toEqual({});
+    });
+});

--- a/packages/loader/src/buildWorldLock.ts
+++ b/packages/loader/src/buildWorldLock.ts
@@ -1,0 +1,58 @@
+/**
+ * buildWorldLock — ワールドが参照する mod の完全性ロックを組み立てる（env非依存）。
+ *
+ * 各 mod がビルド時に出力した `v<ver>/lock.json`（ModLockEntry）を集めて {@link ModLock} を作る。
+ * 取得の transport（HTTP / fs）は `getLockEntry` 注入で分離する。frontend は HTTP、CLI は fs。
+ */
+import { type InitialEntity, type ModLock, type ModLockEntry, ModLockEntrySchema } from '@ubichill/shared';
+import type { FetchLike } from './types';
+
+/** initialEntities ツリーを辿り、使用 mod の modId を重複なく集める純関数。 */
+export function collectModIds(entities: InitialEntity[]): string[] {
+    const ids = new Set<string>();
+    const walk = (e: InitialEntity): void => {
+        for (const c of e.components) {
+            const modId = c.type.split(':')[0];
+            if (modId) ids.add(modId);
+        }
+        for (const child of e.children ?? []) walk(child);
+    };
+    for (const e of entities) walk(e);
+    return [...ids];
+}
+
+/** modId → その mod の lock.json 断片（ModLockEntry）。取得不能なら null。 */
+export type LockEntryGetter = (modId: string) => Promise<ModLockEntry | null>;
+
+/**
+ * modId 群から mod 完全性ロックを構築する。取得できなかった mod は除外する
+ * （＝外部公開時、そのワールドを読む側で lock-missing 拒否になる）。
+ */
+export async function buildWorldLock(modIds: string[], getLockEntry: LockEntryGetter): Promise<ModLock> {
+    const entries = await Promise.all(modIds.map(async (id) => [id, await getLockEntry(id)] as const));
+    const mods = Object.fromEntries(entries.filter((e): e is [string, ModLockEntry] => e[1] !== null));
+    return { lockVersion: 1, mods };
+}
+
+/**
+ * HTTP 経由の {@link LockEntryGetter}。`<baseUrl>/<mod>/mod.json` で version を引き、
+ * `<baseUrl>/<mod>/v<ver>/lock.json` を取得・検証する。frontend/CLI(--base-url) 用。
+ */
+export function createHttpLockEntryGetter(baseUrl: string, fetchImpl?: FetchLike): LockEntryGetter {
+    const f: FetchLike =
+        fetchImpl ?? ((input, init) => fetch(input, init as RequestInit) as unknown as ReturnType<FetchLike>);
+    return async (modId) => {
+        try {
+            const index = await f(`${baseUrl}/${modId}/mod.json`, { cache: 'no-store' });
+            if (!index.ok) return null;
+            const { version } = (await index.json()) as { version?: string };
+            if (!version) return null;
+            const res = await f(`${baseUrl}/${modId}/v${version}/lock.json`, { cache: 'no-store' });
+            if (!res.ok) return null;
+            const parsed = ModLockEntrySchema.safeParse(await res.json());
+            return parsed.success ? parsed.data : null;
+        } catch {
+            return null;
+        }
+    };
+}

--- a/packages/loader/src/buildWorldLock.ts
+++ b/packages/loader/src/buildWorldLock.ts
@@ -4,22 +4,11 @@
  * 各 mod がビルド時に出力した `v<ver>/lock.json`（ModLockEntry）を集めて {@link ModLock} を作る。
  * 取得の transport（HTTP / fs）は `getLockEntry` 注入で分離する。frontend は HTTP、CLI は fs。
  */
-import { type InitialEntity, type ModLock, type ModLockEntry, ModLockEntrySchema } from '@ubichill/shared';
+import { type ModLock, type ModLockEntry, ModLockEntrySchema } from '@ubichill/shared';
 import type { FetchLike } from './types';
 
-/** initialEntities ツリーを辿り、使用 mod の modId を重複なく集める純関数。 */
-export function collectModIds(entities: InitialEntity[]): string[] {
-    const ids = new Set<string>();
-    const walk = (e: InitialEntity): void => {
-        for (const c of e.components) {
-            const modId = c.type.split(':')[0];
-            if (modId) ids.add(modId);
-        }
-        for (const child of e.children ?? []) walk(child);
-    };
-    for (const e of entities) walk(e);
-    return [...ids];
-}
+// modId 収集ロジックは shared に一本化（backend collectMods と共有）。利便のため再エクスポート。
+export { collectModIds } from '@ubichill/shared';
 
 /** modId → その mod の lock.json 断片（ModLockEntry）。取得不能なら null。 */
 export type LockEntryGetter = (modId: string) => Promise<ModLockEntry | null>;

--- a/packages/loader/src/cli.ts
+++ b/packages/loader/src/cli.ts
@@ -1,0 +1,67 @@
+/**
+ * ロック生成 CLI（Node 専用）。ワールド YAML から mod 完全性ロックを生成し、
+ * 兄弟ファイル `<world>.lock.json` に書き出す（分離方針＝YAML には埋めない）。
+ *
+ * 使い方:
+ *   tsx packages/loader/src/cli.ts <world.yaml> [--mods-dir=<dir>] [--base-url=<url>] [--out=<path>]
+ *   （root script: `pnpm gen:lock worlds/default.yaml`）
+ *
+ * getLockEntry の transport:
+ *   - 既定/`--mods-dir`: ローカルの mods ディレクトリ（build-workers 出力）から fs 読取。
+ *   - `--base-url`     : HTTP 取得（外部 CDN 上の mod を固定する場合）。
+ */
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { type ModLockEntry, ModLockEntrySchema, WorldDefinitionSchema } from '@ubichill/shared';
+import yaml from 'yaml';
+import { buildWorldLock, collectModIds, createHttpLockEntryGetter, type LockEntryGetter } from './buildWorldLock';
+
+function argValue(argv: string[], name: string): string | undefined {
+    const hit = argv.find((a) => a.startsWith(`--${name}=`));
+    return hit?.slice(name.length + 3);
+}
+
+/** mods ディレクトリ（build-workers 出力）から lock.json 断片を fs で読む getter。 */
+function createFsLockEntryGetter(modsDir: string): LockEntryGetter {
+    return async (modId) => {
+        const indexPath = join(modsDir, modId, 'mod.json');
+        if (!existsSync(indexPath)) return null;
+        const { version } = JSON.parse(readFileSync(indexPath, 'utf-8')) as { version?: string };
+        if (!version) return null;
+        const lockPath = join(modsDir, modId, `v${version}`, 'lock.json');
+        if (!existsSync(lockPath)) return null;
+        const parsed = ModLockEntrySchema.safeParse(JSON.parse(readFileSync(lockPath, 'utf-8')));
+        return parsed.success ? (parsed.data as ModLockEntry) : null;
+    };
+}
+
+async function main(): Promise<void> {
+    const argv = process.argv.slice(2);
+    const worldPath = argv.find((a) => !a.startsWith('--'));
+    if (!worldPath) {
+        console.error('usage: gen:lock <world.yaml> [--mods-dir=<dir>] [--base-url=<url>] [--out=<path>]');
+        process.exit(1);
+    }
+
+    const def = WorldDefinitionSchema.parse(yaml.parse(readFileSync(worldPath, 'utf-8')));
+    const modIds = collectModIds(def.spec.initialEntities);
+
+    const baseUrl = argValue(argv, 'base-url');
+    const modsDir = argValue(argv, 'mods-dir') ?? 'packages/frontend/public/mods';
+    const getLockEntry = baseUrl ? createHttpLockEntryGetter(baseUrl) : createFsLockEntryGetter(modsDir);
+
+    const lock = await buildWorldLock(modIds, getLockEntry);
+
+    const outPath = argValue(argv, 'out') ?? worldPath.replace(/\.ya?ml$/i, '.lock.json');
+    writeFileSync(outPath, `${JSON.stringify(lock, null, 2)}\n`, 'utf-8');
+
+    const lockedIds = Object.keys(lock.mods);
+    const missing = modIds.filter((id) => !lockedIds.includes(id));
+    console.log(`🔒 ${outPath} (${lockedIds.length}/${modIds.length} mods)`);
+    if (missing.length > 0) console.warn(`⚠️  lock 断片が見つからない mod: ${missing.join(', ')}（除外）`);
+}
+
+main().catch((err) => {
+    console.error('❌ ロック生成失敗:', err instanceof Error ? err.message : err);
+    process.exit(1);
+});

--- a/packages/loader/src/index.ts
+++ b/packages/loader/src/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @ubichill/loader — mod の取得・完全性検証・ロック構築。
+ *
+ * browser+Node 両対応・React/DOM 非依存。frontend（取得+検証）と CLI（ロック生成）が共有する。
+ * 知識（スキーマ / resolveLockedMod）は @ubichill/shared、隔離実行は @ubichill/sandbox。
+ */
+export { type AcquireModOptions, acquireMod, resetAcquireCaches } from './acquireMod';
+export { buildWorldLock, collectModIds, createHttpLockEntryGetter, type LockEntryGetter } from './buildWorldLock';
+export { sriOf } from './integrity';
+export type { AcquireResult, FetchLike, FetchLikeResponse, LoadedMod } from './types';

--- a/packages/loader/src/integrity.test.ts
+++ b/packages/loader/src/integrity.test.ts
@@ -1,0 +1,23 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { sriOf } from './integrity';
+
+describe('sriOf（lock integrity 生成）', () => {
+    it('sha256-<base64> 形式を返す', async () => {
+        const bytes = new TextEncoder().encode('hello').buffer;
+        expect(await sriOf(bytes)).toMatch(/^sha256-[A-Za-z0-9+/]+=*$/);
+    });
+
+    it('build-workers 側（Buffer の sha256 base64）と同一バイト列で一致する', async () => {
+        const code = 'const x = "日本語も含む";';
+        const bytes = new TextEncoder().encode(code);
+        const expected = `sha256-${createHash('sha256').update(Buffer.from(bytes)).digest('base64')}`;
+        expect(await sriOf(bytes.buffer)).toBe(expected);
+    });
+
+    it('1 バイトの差分で integrity が変わる（差し替え検知）', async () => {
+        const a = await sriOf(new TextEncoder().encode('abc').buffer);
+        const b = await sriOf(new TextEncoder().encode('abd').buffer);
+        expect(a).not.toBe(b);
+    });
+});

--- a/packages/loader/src/integrity.ts
+++ b/packages/loader/src/integrity.ts
@@ -1,0 +1,16 @@
+import { formatIntegrity } from '@ubichill/shared';
+
+/**
+ * ArrayBuffer を Subresource Integrity 文字列 `sha256-<base64>` に変換する。
+ *
+ * build 側（`Buffer.from(code,'utf-8')` の sha256 base64）と同一バイト列・同一規約で
+ * 照合できるよう、必ず fetch した生バイト列を渡すこと。
+ *
+ * `globalThis.crypto.subtle` を使うため browser と Node20+ の双方で動く。
+ */
+export async function sriOf(bytes: ArrayBuffer): Promise<string> {
+    const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes);
+    // spread は大きな bundle で stack を溢れさせるため Array.from(mapper) で 1 バイトずつ。
+    const binary = Array.from(new Uint8Array(digest), (b) => String.fromCharCode(b)).join('');
+    return formatIntegrity(btoa(binary));
+}

--- a/packages/loader/src/types.ts
+++ b/packages/loader/src/types.ts
@@ -1,0 +1,44 @@
+import type { LockRejectReason } from '@ubichill/shared';
+
+/**
+ * 取得・検証済みの mod（React/DOM 非依存の中立表現）。
+ * Host 側（frontend）がこれを `WorkerModDefinition` にマップする。
+ */
+export interface LoadedMod {
+    /** Component 型 `modId:componentName`。 */
+    id: string;
+    /** 表示名。 */
+    name: string;
+    /** バンドル済み Worker 実行コード（検証済みバイト列を decode したもの）。 */
+    workerCode: string;
+    /** 付与を許す capability（verified 時は lock 天井、それ以外は manifest 由来）。 */
+    capabilities?: string[];
+    /** versioned アセットベース URL（Worker で `Ubi.modBase`）。 */
+    modBase: string;
+    watchScope: 'entity' | 'subtree' | 'parent' | 'world';
+    watchEntityTypes?: string[];
+    canvasTargets?: string[];
+    mediaTargets?: string[];
+    singleton?: boolean;
+    thumbnail?: string;
+}
+
+/**
+ * {@link acquireMod} の戻り値。
+ *  - LoadedMod   : 取得＋検証成功。
+ *  - 'data-only' : worker を持たない純データ Component（警告不要）。
+ *  - 'not-found' : manifest/worker 取得失敗・未宣言。
+ *  - { rejected }: lock 照合で拒否（外部 provenance）。理由付き。
+ */
+export type AcquireResult = LoadedMod | 'data-only' | 'not-found' | { rejected: LockRejectReason };
+
+/** DOM/Node 共通の最小 fetch シグネチャ（注入用）。 */
+export type FetchLike = (input: string, init?: { cache?: 'no-store' }) => Promise<FetchLikeResponse>;
+
+export interface FetchLikeResponse {
+    ok: boolean;
+    headers: { get(name: string): string | null };
+    json(): Promise<unknown>;
+    text(): Promise<string>;
+    arrayBuffer(): Promise<ArrayBuffer>;
+}

--- a/packages/loader/tsconfig.json
+++ b/packages/loader/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "target": "ES2025",
+        "lib": ["ES2025", "DOM"],
+        "types": ["node"],
+        "strict": true,
+        "noEmit": true,
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "esModuleInterop": true,
+        "resolveJsonModule": true,
+        "declaration": true
+    },
+    "include": ["src/**/*.ts"]
+}

--- a/packages/react/src/hooks/useWorld.tsx
+++ b/packages/react/src/hooks/useWorld.tsx
@@ -3,6 +3,7 @@ import type {
     ComponentInstance,
     EntityEphemeralPayload,
     EntityPatchPayload,
+    ModLock,
     WorldEnvironmentData,
     WorldSnapshotPayload,
 } from '@ubichill/shared';
@@ -20,6 +21,10 @@ export interface WorldContextType {
     environment: WorldEnvironmentData;
     availableComponents: AvailableComponent[];
     activeMods: string[];
+    /** ワールドに焼かれた mod 完全性ロック（あれば）。mod ローダーの hash 照合に使う。 */
+    modLock?: ModLock;
+    /** ワールドの provenance kind（local/github/...）。lock enforcement の分岐に使う。 */
+    worldSourceKind?: string;
     createEntity: <T = Record<string, unknown>>(
         type: string,
         transform: ComponentInstance['transform'],
@@ -49,6 +54,8 @@ export const WorldProvider: React.FC<{ children: React.ReactNode }> = ({ childre
     const [environment, setEnvironment] = useState<WorldEnvironmentData>(DEFAULTS.WORLD_ENVIRONMENT);
     const [availableComponents, setAvailableComponents] = useState<AvailableComponent[]>([]);
     const [activeMods, setActiveMods] = useState<string[]>([]);
+    const [modLock, setModLock] = useState<ModLock | undefined>(undefined);
+    const [worldSourceKind, setWorldSourceKind] = useState<string | undefined>(undefined);
 
     useEffect(() => {
         if (!socket) return;
@@ -63,6 +70,8 @@ export const WorldProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             setEnvironment(payload.environment);
             setAvailableComponents(payload.availableComponents);
             setActiveMods(payload.activeMods || []);
+            setModLock(payload.lock);
+            setWorldSourceKind(payload.sourceKind);
         };
 
         // エンティティ作成を受信
@@ -222,6 +231,8 @@ export const WorldProvider: React.FC<{ children: React.ReactNode }> = ({ childre
         setEnvironment(DEFAULTS.WORLD_ENVIRONMENT);
         setAvailableComponents([]);
         setActiveMods([]);
+        setModLock(undefined);
+        setWorldSourceKind(undefined);
     }, []);
 
     const contextValue: WorldContextType = useMemo(
@@ -231,6 +242,8 @@ export const WorldProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             environment,
             availableComponents,
             activeMods,
+            modLock,
+            worldSourceKind,
             createEntity,
             patchEntity,
             deleteEntity,
@@ -243,6 +256,8 @@ export const WorldProvider: React.FC<{ children: React.ReactNode }> = ({ childre
             environment,
             availableComponents,
             activeMods,
+            modLock,
+            worldSourceKind,
             createEntity,
             patchEntity,
             deleteEntity,

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
+import type { ModLock } from './schemas/modLock.schema';
+
 // ============================================
 // User Types
 // ============================================
@@ -171,6 +173,10 @@ export interface WorldSnapshotPayload {
     /** アクティブなmodIDのリスト */
     activeMods: string[];
     environment: WorldEnvironmentData;
+    /** ワールドに焼かれた mod 完全性ロック（あれば）。ロード時の hash 照合に使う。 */
+    lock?: ModLock;
+    /** ワールドの provenance kind（local/github/...）。lock enforcement の分岐に使う。 */
+    sourceKind?: string;
 }
 
 // ============================================
@@ -404,6 +410,7 @@ export const SERVER_CONFIG = {
 
 export * from './mod/capability';
 export * from './mod/errors';
+export * from './mod/modLock';
 export * from './mod/permission';
 export * from './mod/protocol';
 export * from './mod/types';

--- a/packages/shared/src/mod/modLock.test.ts
+++ b/packages/shared/src/mod/modLock.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { ModLockEntry } from '../schemas/modLock.schema';
+import { WorldSourceKind } from '../schemas/world.schema';
+import { formatIntegrity, integrityEquals, requiresLock, resolveLockedMod } from './modLock';
+
+const WORKER_OK = 'sha256-AAAA';
+const MANIFEST_OK = 'sha256-BBBB';
+
+/** テスト用の lock エントリ。既定は video-player:screen を 1 つ持つ。 */
+function lockEntry(overrides: Partial<ModLockEntry> = {}): ModLockEntry {
+    return {
+        id: 'video-player',
+        version: '2.1.0',
+        manifestIntegrity: MANIFEST_OK,
+        components: {
+            'video-player:screen': {
+                workerUrl: './screen/index.abc.js',
+                integrity: WORKER_OK,
+                capabilities: ['scene:read', 'media:control'],
+            },
+        },
+        ...overrides,
+    };
+}
+
+describe('requiresLock（provenance 別 enforcement）', () => {
+    it('local / registry(official) は lock 不要', () => {
+        expect(requiresLock(WorldSourceKind.Local)).toBe(false);
+        expect(requiresLock(WorldSourceKind.Registry)).toBe(false);
+    });
+
+    it('github / remote-instance / url は lock 必須', () => {
+        expect(requiresLock(WorldSourceKind.GitHub)).toBe(true);
+        expect(requiresLock(WorldSourceKind.RemoteInstance)).toBe(true);
+        expect(requiresLock(WorldSourceKind.Url)).toBe(true);
+    });
+
+    it('未知の kind は安全側で lock 必須', () => {
+        expect(requiresLock('totally-unknown')).toBe(true);
+    });
+});
+
+describe('integrityEquals / formatIntegrity', () => {
+    it('formatIntegrity は sha256- を前置する', () => {
+        expect(formatIntegrity('Zm9v')).toBe('sha256-Zm9v');
+    });
+
+    it('前後空白を無視して一致する', () => {
+        expect(integrityEquals(' sha256-Zm9v ', 'sha256-Zm9v')).toBe(true);
+    });
+
+    it('undefined 同士・片側 undefined は不一致（フェイルセーフ）', () => {
+        expect(integrityEquals(undefined, undefined)).toBe(false);
+        expect(integrityEquals('sha256-Zm9v', undefined)).toBe(false);
+    });
+
+    it('アルゴリズム前置が違えば不一致（部分一致を許さない）', () => {
+        expect(integrityEquals('sha256-Zm9v', 'Zm9v')).toBe(false);
+    });
+});
+
+describe('resolveLockedMod', () => {
+    const base = {
+        entityType: 'video-player:screen',
+        workerIntegrity: WORKER_OK,
+        manifestIntegrity: MANIFEST_OK,
+    };
+
+    it('全一致で verified、capabilities は lock 天井を採用', () => {
+        const v = resolveLockedMod({ ...base, lockEntry: lockEntry(), sourceKind: WorldSourceKind.GitHub });
+        expect(v).toEqual({ status: 'verified', capabilities: ['scene:read', 'media:control'] });
+    });
+
+    it('lock に記載が無い外部 mod は lock-missing で rejected', () => {
+        const v = resolveLockedMod({ ...base, lockEntry: undefined, sourceKind: WorldSourceKind.Url });
+        expect(v).toEqual({ status: 'rejected', reason: 'lock-missing' });
+    });
+
+    it('lock に記載が無くても local なら unlocked（従来挙動で続行）', () => {
+        const v = resolveLockedMod({ ...base, lockEntry: undefined, sourceKind: WorldSourceKind.Local });
+        expect(v).toEqual({ status: 'unlocked' });
+    });
+
+    it('entityType が lock の components に無ければ（別 component）外部は lock-missing', () => {
+        const v = resolveLockedMod({
+            ...base,
+            entityType: 'video-player:controls',
+            lockEntry: lockEntry(),
+            sourceKind: WorldSourceKind.GitHub,
+        });
+        expect(v).toEqual({ status: 'rejected', reason: 'lock-missing' });
+    });
+
+    it('manifest hash 不一致は worker より先に manifest-mismatch を返す', () => {
+        const v = resolveLockedMod({
+            ...base,
+            manifestIntegrity: 'sha256-TAMPERED',
+            workerIntegrity: 'sha256-ALSO-BAD',
+            lockEntry: lockEntry(),
+            sourceKind: WorldSourceKind.GitHub,
+        });
+        expect(v).toEqual({ status: 'rejected', reason: 'manifest-mismatch' });
+    });
+
+    it('worker バイト列差し替えは integrity-mismatch', () => {
+        const v = resolveLockedMod({
+            ...base,
+            workerIntegrity: 'sha256-SWAPPED',
+            lockEntry: lockEntry(),
+            sourceKind: WorldSourceKind.GitHub,
+        });
+        expect(v).toEqual({ status: 'rejected', reason: 'integrity-mismatch' });
+    });
+
+    it('配布者が manifest で権限を増やしても lock 天井のみが採用される（昇格不能）', () => {
+        // lock は scene:read/media:control のみ。manifest 側の申告は resolveLockedMod に渡らず、
+        // verified の capabilities は lock の 2 件に固定される。
+        const v = resolveLockedMod({ ...base, lockEntry: lockEntry(), sourceKind: WorldSourceKind.RemoteInstance });
+        expect(v.status).toBe('verified');
+        if (v.status === 'verified') {
+            expect(v.capabilities).not.toContain('net:fetch');
+            expect([...v.capabilities].sort()).toEqual(['media:control', 'scene:read']);
+        }
+    });
+
+    it('local でも lock 記載があれば hash 照合し、不一致は rejected（続行判断は loader）', () => {
+        const v = resolveLockedMod({
+            ...base,
+            workerIntegrity: 'sha256-LOCAL-TAMPER',
+            lockEntry: lockEntry(),
+            sourceKind: WorldSourceKind.Local,
+        });
+        expect(v).toEqual({ status: 'rejected', reason: 'integrity-mismatch' });
+    });
+});

--- a/packages/shared/src/mod/modLock.ts
+++ b/packages/shared/src/mod/modLock.ts
@@ -1,0 +1,110 @@
+/**
+ * modLock — mod 完全性ロックの純粋ロジック。
+ *
+ * fetch / crypto（副作用）は呼び出し側（フロント loader・build スクリプト）が担い、
+ * ここは「provenance からの enforcement 判定」と「計算済み digest の照合」だけを
+ * 純関数で提供する。これによりロジックを crypto/fetch なしで意地悪にテストできる。
+ *
+ * 信頼モデル: lock はワールド YAML に埋め込まれ、ワールド URL の provenance が
+ * 信頼根になる。capability は lock を天井とし、manifest（配布者の自己申告）を
+ * 一切参照しない。コードバイト列が lock と一致する以上、真の必要権限＝lock。
+ */
+import type { ModLockComponent, ModLockEntry } from '../schemas/modLock.schema';
+import { WorldSourceKind } from '../schemas/world.schema';
+
+/**
+ * この provenance の mod は lock を必須とするか。
+ * - local / registry(official): 本体が配る信頼済み。開発利便のため lock 無しでも許可（lenient）。
+ * - github / remote-instance / url: 外部配布。lock 必須・不一致は拒否（strict）。
+ *
+ * 未知の kind は安全側に倒して strict（要 lock）とする。
+ */
+export function requiresLock(kind: string): boolean {
+    switch (kind) {
+        case WorldSourceKind.Local:
+        case WorldSourceKind.Registry:
+            return false;
+        default:
+            return true;
+    }
+}
+
+/** integrity（`sha256-<base64>`）を base64 digest から組み立てる。 */
+export function formatIntegrity(base64Digest: string): string {
+    return `sha256-${base64Digest}`;
+}
+
+/**
+ * integrity 文字列の一致判定。
+ * 前後空白を無視した完全一致のみ許す（アルゴリズム混在や部分一致は不許可）。
+ */
+export function integrityEquals(a: string | undefined, b: string | undefined): boolean {
+    if (!a || !b) return false;
+    return a.trim() === b.trim();
+}
+
+/** {@link resolveLockedMod} が返す拒否理由。 */
+export type LockRejectReason =
+    /** 外部 provenance なのに lock にこの mod/component の記載が無い。 */
+    | 'lock-missing'
+    /** worker バイト列が lock の integrity と一致しない。 */
+    | 'integrity-mismatch'
+    /** versioned manifest が lock の manifestIntegrity と一致しない。 */
+    | 'manifest-mismatch';
+
+/**
+ * lock 検証の判定。取得層（loader）はこれを見て capability 源と続行可否を決める。
+ * - `verified` : lock 記載あり＋バイト列一致。capabilities は lock 天井を採用する。
+ * - `unlocked` : lock 記載なし＆ local/official。従来挙動（manifest capabilities）で続行。
+ * - `rejected` : lock 必須なのに記載なし、または hash 不一致。外部は拒否、local は警告続行。
+ */
+export type LockVerdict =
+    | { status: 'verified'; capabilities: readonly string[] }
+    | { status: 'unlocked' }
+    | { status: 'rejected'; reason: LockRejectReason };
+
+export interface ResolveLockedModArgs {
+    /** `modId:componentName`。 */
+    entityType: string;
+    /** ワールドの lock からこの mod を引いたエントリ（無ければ undefined）。 */
+    lockEntry: ModLockEntry | undefined;
+    /** 計算済みの worker バイト列 integrity（`sha256-<base64>`）。 */
+    workerIntegrity: string;
+    /** 計算済みの versioned manifest integrity（`sha256-<base64>`）。 */
+    manifestIntegrity: string;
+    /** ワールドの provenance kind（local/github/... enforcement 分岐に使う）。 */
+    sourceKind: string;
+}
+
+/**
+ * lock に対して mod を検証する純関数。fetch/crypto は呼び出し側で済ませて渡す。
+ *
+ * 判定順:
+ *  1. lock 記載が無い → 外部(requiresLock)は 'lock-missing' で rejected、
+ *     local は 'unlocked'（従来挙動で続行）。
+ *  2. manifest hash 不一致 → 'manifest-mismatch'。
+ *  3. worker hash 不一致 → 'integrity-mismatch'。
+ *  4. 全一致 → verified（capabilities は lock 由来のみ＝天井）。
+ *
+ * rejected の続行/拒否の最終判断は loader が sourceKind（requiresLock）で決める。
+ * workerUrl は loader が lock/manifest から持つのでここでは返さない。
+ */
+export function resolveLockedMod(args: ResolveLockedModArgs): LockVerdict {
+    const { entityType, lockEntry, workerIntegrity, manifestIntegrity, sourceKind } = args;
+
+    const component: ModLockComponent | undefined = lockEntry?.components[entityType];
+
+    if (!lockEntry || !component) {
+        // 外部 provenance は lock 必須。local は lock 無しでも従来通り許可。
+        return requiresLock(sourceKind) ? { status: 'rejected', reason: 'lock-missing' } : { status: 'unlocked' };
+    }
+
+    if (!integrityEquals(manifestIntegrity, lockEntry.manifestIntegrity)) {
+        return { status: 'rejected', reason: 'manifest-mismatch' };
+    }
+    if (!integrityEquals(workerIntegrity, component.integrity)) {
+        return { status: 'rejected', reason: 'integrity-mismatch' };
+    }
+
+    return { status: 'verified', capabilities: component.capabilities };
+}

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -31,6 +31,16 @@ export {
     type VersionedComponentManifestEntry,
     VersionedComponentManifestEntrySchema,
 } from './mod.schema';
+// Mod Lock スキーマ
+export {
+    IntegritySchema,
+    type ModLock,
+    type ModLockComponent,
+    ModLockComponentSchema,
+    type ModLockEntry,
+    ModLockEntrySchema,
+    ModLockSchema,
+} from './modLock.schema';
 export {
     AuthorSchema,
     type ComponentType,

--- a/packages/shared/src/schemas/index.ts
+++ b/packages/shared/src/schemas/index.ts
@@ -45,6 +45,7 @@ export {
     AuthorSchema,
     type ComponentType,
     ComponentTypeSchema,
+    collectModIds,
     type EntityComponentDef,
     EntityComponentSchema,
     type EntityTag,

--- a/packages/shared/src/schemas/modLock.schema.ts
+++ b/packages/shared/src/schemas/modLock.schema.ts
@@ -16,8 +16,12 @@ import { z } from 'zod';
 // バスティング用途のまま温存し、lock はフル sha256 を別途保持する。
 // ============================================
 
-/** integrity 文字列（`sha256-<base64>`）。 */
-export const IntegritySchema = z.string().regex(/^sha256-[A-Za-z0-9+/]+=*$/, 'Must be "sha256-<base64>"');
+/**
+ * integrity 文字列（`sha256-<base64>`）。
+ * sha256 は 32 byte ＝ 標準 base64 で必ず 43 文字 + `=` 1 個（計 44）になるため長さも固定する。
+ * 任意長を許すと `sha256-AAAA` のような不正値を弾けない。
+ */
+export const IntegritySchema = z.string().regex(/^sha256-[A-Za-z0-9+/]{43}=$/, 'Must be "sha256-<base64(32byte)>"');
 
 /**
  * lock された 1 つの Component。

--- a/packages/shared/src/schemas/modLock.schema.ts
+++ b/packages/shared/src/schemas/modLock.schema.ts
@@ -1,0 +1,59 @@
+import { z } from 'zod';
+
+// ============================================
+// Mod Lock スキーマ（ワールドに埋め込む mod 完全性ロック）
+//
+// 設計:
+// - ワールドは mod を「最新ポインタ」で無検証ロードするため、mod 公開者が
+//   同一 version のままバンドルを差し替えれば任意コード注入・権限昇格ができる。
+// - lock は各 mod の「固定 version + コード hash + capability 上限」を宣言し、
+//   ロード時に fetch したバイト列と照合する（Subresource Integrity 相当）。
+// - capability は lock を天井とし、manifest（配布者の自己申告）を信頼しない。
+// - lock はワールド YAML の `spec.lock` に埋め込むため、ワールド URL の provenance が
+//   そのまま lock の信頼根になる（プレイヤーは mod 公開者を信頼しなくてよい）。
+//
+// integrity は SRI 形式 `sha256-<base64>`。既存のファイル名 hex8 はキャッシュ
+// バスティング用途のまま温存し、lock はフル sha256 を別途保持する。
+// ============================================
+
+/** integrity 文字列（`sha256-<base64>`）。 */
+export const IntegritySchema = z.string().regex(/^sha256-[A-Za-z0-9+/]+=*$/, 'Must be "sha256-<base64>"');
+
+/**
+ * lock された 1 つの Component。
+ * `modId:componentName` 形式のキーで {@link ModLockEntrySchema.components} に格納される。
+ */
+export const ModLockComponentSchema = z.object({
+    /** versioned ディレクトリからの相対 workerUrl（manifest と同形）。 */
+    workerUrl: z.string(),
+    /** worker バンドルのバイト列 sha256（SRI）。 */
+    integrity: IntegritySchema,
+    /** 付与を許す capability の上限（ビルド時に固定した値）。 */
+    capabilities: z.array(z.string()).default([]),
+});
+
+export type ModLockComponent = z.infer<typeof ModLockComponentSchema>;
+
+/**
+ * lock された 1 つの mod（固定 version + manifest hash + component 群）。
+ * data-only Component（worker 無し）は components に載らない。
+ */
+export const ModLockEntrySchema = z.object({
+    id: z.string(),
+    /** 固定した解決バージョン（最新ポインタを信頼せずこの版を直接取得する）。 */
+    version: z.string(),
+    /** versioned manifest.json のバイト列 sha256（SRI）。メタ改ざん検知用。 */
+    manifestIntegrity: IntegritySchema,
+    /** `modId:componentName` → lock 済み Component。 */
+    components: z.record(z.string(), ModLockComponentSchema).default({}),
+});
+
+export type ModLockEntry = z.infer<typeof ModLockEntrySchema>;
+
+/** ワールドが固定する mod ロック全体（`modId` → entry）。 */
+export const ModLockSchema = z.object({
+    lockVersion: z.literal(1),
+    mods: z.record(z.string(), ModLockEntrySchema).default({}),
+});
+
+export type ModLock = z.infer<typeof ModLockSchema>;

--- a/packages/shared/src/schemas/world.schema.ts
+++ b/packages/shared/src/schemas/world.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { ModLockSchema } from './modLock.schema';
 
 // ============================================
 // 定数
@@ -314,6 +315,9 @@ export const WorldDefinitionSchema = z.object({
         dependencies: z.array(DependencySchema).optional(),
         initialEntities: InitialEntitiesSchema,
         permissions: WorldPermissionsSchema.optional(),
+        // mod 完全性ロック（保存時に焼き込む）。外部 provenance のワールドでは
+        // ロード時にこの hash と照合し、不一致 mod の実行を拒否する。
+        lock: ModLockSchema.optional(),
     }),
 });
 
@@ -377,6 +381,8 @@ export const ResolvedWorldSchema = z.object({
     initialEntities: z.array(InitialEntitySchema),
     /** このワールドが使う mod 一覧（component 型と dependencies から算出。version は dependency 宣言由来）。 */
     mods: z.array(WorldModSchema).default([]),
+    /** mod 完全性ロック（あれば）。ロード時の hash 照合・capability 天井に使う。 */
+    lock: ModLockSchema.optional(),
 });
 
 export type ResolvedWorld = z.infer<typeof ResolvedWorldSchema>;

--- a/packages/shared/src/schemas/world.schema.ts
+++ b/packages/shared/src/schemas/world.schema.ts
@@ -268,6 +268,24 @@ export const InitialEntitiesSchema = z
         }
     });
 
+/**
+ * initialEntities ツリー（子孫含む）を走査し、使用 mod の modId を重複なく集める純関数。
+ * component 型 `modId:componentName` の modId 部分を拾う。
+ * loader（lock 構築）と backend（collectMods）が共有する単一の走査ロジック。
+ */
+export function collectModIds(entities: InitialEntity[]): string[] {
+    const ids = new Set<string>();
+    const walk = (e: InitialEntity): void => {
+        for (const c of e.components) {
+            const modId = c.type.split(':')[0];
+            if (modId) ids.add(modId);
+        }
+        for (const child of e.children ?? []) walk(child);
+    };
+    for (const e of entities) walk(e);
+    return [...ids];
+}
+
 // ============================================
 // World Permissions（権限設定）
 // ============================================

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,6 +195,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@ubichill/loader':
+        specifier: workspace:*
+        version: link:../loader
       '@ubichill/react':
         specifier: workspace:*
         version: link:../react
@@ -256,6 +259,16 @@ importers:
       vite:
         specifier: ^8.0.10
         version: 8.0.10(@types/node@22.19.7)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.8.2)
+
+  packages/loader:
+    dependencies:
+      '@ubichill/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      yaml:
+        specifier: ^2.5.0
+        version: 2.8.2
 
   packages/react:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@ubichill/shared':
+        specifier: workspace:*
+        version: link:packages/shared
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -265,7 +265,6 @@ importers:
       '@ubichill/shared':
         specifier: workspace:*
         version: link:../shared
-    devDependencies:
       yaml:
         specifier: ^2.5.0
         version: 2.8.2

--- a/scripts/build-and-load.integration.test.mjs
+++ b/scripts/build-and-load.integration.test.mjs
@@ -1,0 +1,109 @@
+/**
+ * build-workers.mjs（実ビルド）と @ubichill/loader（実ロード検証）を繋ぐ結合テスト。
+ *
+ * これまでの単体テストは「build側のhash計算」と「load側のhash照合」を別々のフェイク値で
+ * 検証しており、両者が本当に同じ規約で一致するかは手動確認に頼っていた。ここでは実際に
+ * `mods/pen` を esbuild でビルドし、生成された本物のバイト列を acquireMod に読ませることで、
+ * ビルド→保存→ロードの契約を自動テストとして固定する。
+ *
+ * リポジトリの実ファイル（packages/frontend/public/mods）は汚さず、一時ディレクトリへビルドする
+ * （buildWorker の publicModsDir/distModsDir 注入を利用）。
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { acquireMod, buildWorldLock, createHttpLockEntryGetter, resetAcquireCaches } from '@ubichill/loader';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { buildWorker } from './build-workers.mjs';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const repoRoot = join(__dirname, '..');
+const penModJson = join(repoRoot, 'mods', 'pen', 'mod.json');
+
+/** input をそのまま絶対 fs パスとして扱う FetchLike（テスト専用。FetchLike は Promise を返す契約）。 */
+async function fsFetch(input) {
+    let bytes;
+    try {
+        bytes = readFileSync(input);
+    } catch {
+        return { ok: false, headers: { get: () => null }, json: async () => null, text: async () => '', arrayBuffer: async () => new ArrayBuffer(0) };
+    }
+    return {
+        ok: true,
+        headers: { get: () => null },
+        json: async () => JSON.parse(bytes.toString('utf-8')),
+        text: async () => bytes.toString('utf-8'),
+        arrayBuffer: async () => bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength),
+    };
+}
+
+describe('build-workers → loader 結合テスト（実ビルド × 実hash照合）', () => {
+    let publicDir;
+    let distDir;
+    let workerFilePath;
+    let manifestFilePath;
+
+    beforeAll(async () => {
+        publicDir = mkdtempSync(join(tmpdir(), 'ubichill-mod-public-'));
+        distDir = mkdtempSync(join(tmpdir(), 'ubichill-mod-dist-'));
+        await buildWorker(penModJson, { publicModsDir: publicDir, distModsDir: distDir });
+
+        const lockEntry = JSON.parse(readFileSync(join(publicDir, 'pen', 'v2.0.0', 'lock.json'), 'utf-8'));
+        const relWorkerUrl = lockEntry.components['pen:canvas'].workerUrl.replace(/^\.\//, '');
+        workerFilePath = join(publicDir, 'pen', 'v2.0.0', relWorkerUrl);
+        manifestFilePath = join(publicDir, 'pen', 'v2.0.0', 'manifest.json');
+    });
+
+    afterAll(() => {
+        rmSync(publicDir, { recursive: true, force: true });
+        rmSync(distDir, { recursive: true, force: true });
+    });
+
+    afterEach(() => resetAcquireCaches());
+
+    it('実ビルド成果物は無改変なら verified、capabilities は lock 天井と一致する', async () => {
+        const lock = await buildWorldLock(['pen'], createHttpLockEntryGetter(publicDir, fsFetch));
+        const result = await acquireMod('pen:canvas', { baseUrl: publicDir, lock, sourceKind: 'github', fetchImpl: fsFetch });
+
+        expect(typeof result === 'object' && 'workerCode' in result).toBe(true);
+        expect(result.workerCode.length).toBeGreaterThan(0);
+        expect(result.capabilities).toEqual(lock.mods.pen.components['pen:canvas'].capabilities);
+    });
+
+    it('worker バイト列を1バイト改竄すると外部 provenance では integrity-mismatch で拒否される', async () => {
+        const lock = await buildWorldLock(['pen'], createHttpLockEntryGetter(publicDir, fsFetch));
+        const original = readFileSync(workerFilePath);
+        writeFileSync(workerFilePath, Buffer.concat([original, Buffer.from(' ')]));
+        try {
+            const result = await acquireMod('pen:canvas', { baseUrl: publicDir, lock, sourceKind: 'github', fetchImpl: fsFetch });
+            expect(result).toEqual({ rejected: 'integrity-mismatch' });
+        } finally {
+            writeFileSync(workerFilePath, original);
+        }
+    });
+
+    it('manifest.json を改竄すると外部 provenance では manifest-mismatch で拒否される', async () => {
+        const lock = await buildWorldLock(['pen'], createHttpLockEntryGetter(publicDir, fsFetch));
+        const original = readFileSync(manifestFilePath);
+        writeFileSync(manifestFilePath, Buffer.concat([original, Buffer.from(' ')]));
+        try {
+            const result = await acquireMod('pen:canvas', { baseUrl: publicDir, lock, sourceKind: 'remote-instance', fetchImpl: fsFetch });
+            expect(result).toEqual({ rejected: 'manifest-mismatch' });
+        } finally {
+            writeFileSync(manifestFilePath, original);
+        }
+    });
+
+    it('local provenance は同じ改竄でも警告続行し、manifest 由来の capabilities で読み込む', async () => {
+        const lock = await buildWorldLock(['pen'], createHttpLockEntryGetter(publicDir, fsFetch));
+        const original = readFileSync(workerFilePath);
+        writeFileSync(workerFilePath, Buffer.concat([original, Buffer.from(' ')]));
+        try {
+            const result = await acquireMod('pen:canvas', { baseUrl: publicDir, lock, sourceKind: 'local', fetchImpl: fsFetch });
+            expect(typeof result === 'object' && 'workerCode' in result).toBe(true);
+        } finally {
+            writeFileSync(workerFilePath, original);
+        }
+    });
+});

--- a/scripts/build-workers.mjs
+++ b/scripts/build-workers.mjs
@@ -169,16 +169,24 @@ function findModJsonFiles(modsDir) {
 // ビルド
 // ============================================================
 
-export async function buildWorker(modJsonPath) {
+/**
+ * @param modJsonPath mod.json への絶対パス
+ * @param options.publicModsDir frontend 配信用 mods/ の出力先（既定: packages/frontend/public/mods）。
+ *   結合テストが実リポジトリを汚さず一時ディレクトリへビルドできるよう注入可能にしている。
+ * @param options.distModsDir CDN 配布用 dist/mods/ の出力先（既定: モジュールスコープの distModsDir）。
+ */
+export async function buildWorker(modJsonPath, options = {}) {
     const modDir = dirname(modJsonPath);
     const modJson = JSON.parse(readFileSync(modJsonPath, 'utf-8'));
 
     const modId = modJson.id;
     const modDirName = basename(modDir);
     const version = modJson.version;
-    const publicModDir = join(root, 'packages', 'frontend', 'public', 'mods', modDirName);
+    const publicModsDir = options.publicModsDir ?? join(root, 'packages', 'frontend', 'public', 'mods');
+    const distModsDirResolved = options.distModsDir ?? distModsDir;
+    const publicModDir = join(publicModsDir, modDirName);
     const publicVersionDir = join(publicModDir, `v${version}`);
-    const distVersionDir = join(distModsDir, modDirName, `v${version}`);
+    const distVersionDir = join(distModsDirResolved, modDirName, `v${version}`);
 
     // tsconfig 検索
     const rootTsconfig = join(modDir, 'tsconfig.json');
@@ -189,8 +197,8 @@ export async function buildWorker(modJsonPath) {
     const rootIndex = JSON.stringify({ id: modId, name: modJson.name, version }, null, 2);
     mkdirSync(publicModDir, { recursive: true });
     writeFileSync(join(publicModDir, 'mod.json'), rootIndex, 'utf-8');
-    mkdirSync(join(distModsDir, modDirName), { recursive: true });
-    writeFileSync(join(distModsDir, modDirName, 'mod.json'), rootIndex, 'utf-8');
+    mkdirSync(join(distModsDirResolved, modDirName), { recursive: true });
+    writeFileSync(join(distModsDirResolved, modDirName, 'mod.json'), rootIndex, 'utf-8');
 
     // ── バージョン付きマニフェスト（ランタイム用・src なし・workerUrl 明示） ──
     // src はビルド時のみ必要なため除去。workerUrl でロード先を明示する。

--- a/scripts/build-workers.mjs
+++ b/scripts/build-workers.mjs
@@ -123,6 +123,15 @@ export function detectCapabilities(code) {
         .sort();
 }
 
+/**
+ * バイト列（utf-8 文字列）の Subresource Integrity 文字列 `sha256-<base64>` を返す。
+ * shared の formatIntegrity と同一規約。ロード側（crypto.subtle）が同じバイト列を
+ * hash して照合するため、書き出す文字列そのものを渡すこと。
+ */
+export function sriOf(text) {
+    return `sha256-${createHash('sha256').update(text, 'utf-8').digest('base64')}`;
+}
+
 async function bundleWorker(entryPath, tsconfig, defines) {
     const result = await esbuild.build({
         entryPoints: [entryPath],
@@ -197,6 +206,8 @@ export async function buildWorker(modJsonPath) {
 
     // バージョン付きマニフェスト用 components（src 除去・workerUrl 追加、フル型キー化）
     const versionedComponents = {};
+    // lock.json 用 components（worker を持つ Component のみ。integrity=フル sha256）。
+    const lockComponents = {};
 
     for (const [componentName, componentEntry] of Object.entries(componentEntries)) {
         // ワールド YAML / runtime からは "modId:componentName" で参照する
@@ -242,10 +253,19 @@ export async function buildWorker(modJsonPath) {
 
         // workerUrl を明示、src（ビルド時のみ）は除去。capabilities は自動生成値で上書き。
         const { src: _src, ...runtimeMeta } = typeof componentEntry === 'string' ? {} : componentEntry;
+        const workerUrl = `./${componentName}/${outFilename}`;
         versionedComponents[componentType] = {
             ...runtimeMeta,
             capabilities,
-            workerUrl: `./${componentName}/${outFilename}`,
+            workerUrl,
+        };
+
+        // lock: worker バイト列のフル sha256 + capability 天井を固定する。
+        // integrity はロード側が同一バイト列（書き出す code そのもの）を hash して照合する。
+        lockComponents[componentType] = {
+            workerUrl,
+            integrity: sriOf(code),
+            capabilities,
         };
 
         console.log(
@@ -277,6 +297,23 @@ export async function buildWorker(modJsonPath) {
     );
     writeFileSync(join(distVersionDir, 'manifest.json'), versionedManifest, 'utf-8');
     writeFileSync(join(publicVersionDir, 'manifest.json'), versionedManifest, 'utf-8');
+
+    // ── lock.json（ModLockEntry 形状）─────────────────────────────
+    // ワールド保存時にこの断片を取り込み spec.lock に固定する。
+    // manifestIntegrity は上で書き出した manifest 文字列そのものの hash。
+    const lock = JSON.stringify(
+        {
+            id: modId,
+            version,
+            manifestIntegrity: sriOf(versionedManifest),
+            components: lockComponents,
+        },
+        null,
+        2,
+    );
+    writeFileSync(join(distVersionDir, 'lock.json'), lock, 'utf-8');
+    writeFileSync(join(publicVersionDir, 'lock.json'), lock, 'utf-8');
+    console.log(`🔒 [${modId}] lock.json (${Object.keys(lockComponents).length} components)`);
 }
 
 // ============================================================

--- a/scripts/build-workers.test.mjs
+++ b/scripts/build-workers.test.mjs
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
-import { detectCapabilities } from './build-workers.mjs';
+import { detectCapabilities, sriOf } from './build-workers.mjs';
 
 describe('detectCapabilities（Ubi API の静的検出）', () => {
     it('Ubi.fetch から net:fetch を検出する', () => {
@@ -46,5 +47,23 @@ describe('detectCapabilities（Ubi API の静的検出）', () => {
     it('結果はソート済み・重複なし', () => {
         const caps = detectCapabilities('Ubi.entity.self; Ubi.entity.query(); Ubi.ui.render();');
         expect(caps).toEqual([...new Set(caps)].sort());
+    });
+});
+
+describe('sriOf（lock integrity 生成）', () => {
+    it('sha256-<base64> 形式を返す', () => {
+        expect(sriOf('hello')).toMatch(/^sha256-[A-Za-z0-9+/]+=*$/);
+    });
+
+    it('ロード側と同一バイト列の hash に一致する（utf-8, base64）', () => {
+        const code = 'const x = "日本語も含む";';
+        // フロントは fetch した生バイト列（utf-8）を crypto.subtle で hash する。
+        // 同じバイト列を Buffer 経由で hash した値と一致しなければ照合が破綻する。
+        const expected = `sha256-${createHash('sha256').update(Buffer.from(code, 'utf-8')).digest('base64')}`;
+        expect(sriOf(code)).toBe(expected);
+    });
+
+    it('1 バイトの差分で integrity が変わる（差し替え検知）', () => {
+        expect(sriOf('abc')).not.toBe(sriOf('abd'));
     });
 });

--- a/scripts/verify-mod-locks.mjs
+++ b/scripts/verify-mod-locks.mjs
@@ -1,0 +1,97 @@
+/**
+ * verify-mod-locks.mjs
+ *
+ * build-workers.mjs が出力した lock.json 群を「配布前」に検証する fail-closed ゲート。
+ *
+ * ここで検証するのは、build 側が生成した lock の integrity が「実際に配布されるバイト列」と
+ * 一致しているか。build-workers.mjs 自身の hash 計算にバグがあっても単体テストはフェイク値を
+ * 使うため気づけない。ここは実ファイルシステム上の生成物を独立に再ハッシュして突き合わせる、
+ * 唯一の「実際に配布する物」に対するチェック。
+ *
+ * - GitHub Pages 公開ワークフロー（mods-pages.yml）が push 前に実行し、不一致なら公開を止める。
+ * - 通常 CI（ci.yml）も build:workers 直後に実行し、PR 段階で壊れたビルドを検知する。
+ *
+ * 使い方: node scripts/verify-mod-locks.mjs [--dist-dir=dist/mods]
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ModLockEntrySchema } from '@ubichill/shared';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+const distDirArg = process.argv.slice(2).find((a) => a.startsWith('--dist-dir='));
+const distModsDir = distDirArg ? join(root, distDirArg.split('=')[1]) : join(root, 'dist', 'mods');
+
+function sriOf(buffer) {
+    return `sha256-${createHash('sha256').update(buffer).digest('base64')}`;
+}
+
+/** 1 mod のディレクトリを検証する。問題があれば文字列配列で返す（空なら OK）。 */
+function verifyModDir(modDir, modDirName) {
+    const errors = [];
+    for (const versionDirName of readdirSync(modDir).filter((n) => /^v/.test(n))) {
+        const versionDir = join(modDir, versionDirName);
+        const lockPath = join(versionDir, 'lock.json');
+        if (!existsSync(lockPath)) continue; // data-only mod 等、lock.json が無い場合はスキップ
+
+        // lock.json は ModLockEntry 単体（buildWorker が mod 単位で出す形）。スキーマ違反も検出する。
+        const parsed = ModLockEntrySchema.safeParse(JSON.parse(readFileSync(lockPath, 'utf-8')));
+        if (!parsed.success) {
+            errors.push(`${modDirName}/${versionDirName}: lock.json がスキーマ不正 (${parsed.error.issues[0]?.message})`);
+            continue;
+        }
+        const rawLock = parsed.data;
+
+        const manifestPath = join(versionDir, 'manifest.json');
+        if (!existsSync(manifestPath)) {
+            errors.push(`${modDirName}/${versionDirName}: manifest.json が無い`);
+            continue;
+        }
+        const manifestIntegrity = sriOf(readFileSync(manifestPath));
+        if (manifestIntegrity !== rawLock.manifestIntegrity) {
+            errors.push(
+                `${modDirName}/${versionDirName}: manifestIntegrity 不一致 (lock=${rawLock.manifestIntegrity}, 実測=${manifestIntegrity})`,
+            );
+        }
+
+        for (const [componentType, comp] of Object.entries(rawLock.components ?? {})) {
+            const workerPath = join(versionDir, comp.workerUrl.replace(/^\.\//, ''));
+            if (!existsSync(workerPath)) {
+                errors.push(`${modDirName}/${versionDirName}/${componentType}: workerUrl が指すファイルが無い (${comp.workerUrl})`);
+                continue;
+            }
+            const workerIntegrity = sriOf(readFileSync(workerPath));
+            if (workerIntegrity !== comp.integrity) {
+                errors.push(
+                    `${modDirName}/${versionDirName}/${componentType}: integrity 不一致 (lock=${comp.integrity}, 実測=${workerIntegrity})`,
+                );
+            }
+        }
+    }
+    return errors;
+}
+
+function main() {
+    if (!existsSync(distModsDir)) {
+        console.error(`❌ ${distModsDir} が存在しません（先に pnpm build:workers を実行してください）`);
+        process.exit(1);
+    }
+
+    const modDirNames = readdirSync(distModsDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
+
+    const allErrors = modDirNames.flatMap((name) => verifyModDir(join(distModsDir, name), name));
+
+    if (allErrors.length > 0) {
+        console.error(`❌ mod lock 検証失敗 (${allErrors.length} 件):`);
+        for (const e of allErrors) console.error(`  - ${e}`);
+        process.exit(1);
+    }
+    console.log(`✅ mod lock 検証OK (${modDirNames.length} mods)`);
+}
+
+main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     resolve: {
         alias: {
             '@ubichill/shared': srcPath('./packages/shared/src/index.ts'),
+            '@ubichill/loader': srcPath('./packages/loader/src/index.ts'),
             '@ubichill/ecs': srcPath('./packages/ecs/src/index.ts'),
             '@ubichill/sdk': srcPath('./packages/sdk/src/index.ts'),
             '@ubichill/ui-renderer': srcPath('./packages/ui-renderer/src/index.ts'),

--- a/worlds/default.lock.json
+++ b/worlds/default.lock.json
@@ -1,0 +1,88 @@
+{
+  "lockVersion": 1,
+  "mods": {
+    "video-player": {
+      "id": "video-player",
+      "version": "2.1.0",
+      "manifestIntegrity": "sha256-n/Psv+OO+P0SpeMbnb3CqOhM1QmQNxsSx120cyHcSiM=",
+      "components": {
+        "video-player:screen": {
+          "workerUrl": "./screen/index.62113a7f.js",
+          "integrity": "sha256-YhE6fy4AgW9YrkyS9IskyHLQl4oTMGK2pMVQpnfFaXg=",
+          "capabilities": [
+            "event:emit",
+            "media:control"
+          ]
+        },
+        "video-player:controls": {
+          "workerUrl": "./controls/index.2003d3c8.js",
+          "integrity": "sha256-IAPTyL0KeK9106SCqGbGR4fA4rbgEdSMq8Zu4hWG6v0=",
+          "capabilities": [
+            "event:emit",
+            "scene:read",
+            "scene:update",
+            "ui:render"
+          ]
+        },
+        "video-player:playlist": {
+          "workerUrl": "./playlist/index.87ad116c.js",
+          "integrity": "sha256-h60RbFbVhwD9/ShpdJTSO4jsa5LV10ogXqZ5DgerUQQ=",
+          "capabilities": [
+            "event:emit",
+            "scene:read",
+            "scene:update",
+            "ui:render"
+          ]
+        },
+        "video-player:search": {
+          "workerUrl": "./search/index.2ee59a37.js",
+          "integrity": "sha256-LuWaN/t3EpXrOvMr22v3E7Fr6L68TtuIP370U+a4lXs=",
+          "capabilities": [
+            "event:emit",
+            "net:fetch",
+            "scene:read",
+            "ui:render"
+          ]
+        }
+      }
+    },
+    "pen": {
+      "id": "pen",
+      "version": "2.0.0",
+      "manifestIntegrity": "sha256-yVAPiusOupC8E4wb2Lp1ZJ1y0v4sD7GW1jpLrkmUFUg=",
+      "components": {
+        "pen:canvas": {
+          "workerUrl": "./canvas/index.d6c19ea7.js",
+          "integrity": "sha256-1sGepxPaSyfjACiKHtdbo1o5MSgvngRXFwHc4KshmKs=",
+          "capabilities": [
+            "canvas:draw",
+            "event:broadcast",
+            "event:emit",
+            "scene:read",
+            "scene:update"
+          ]
+        },
+        "pen:tray": {
+          "workerUrl": "./tray/index.2269a184.js",
+          "integrity": "sha256-ImmhhD102fBdy1YsXy0DRLletNEfknEKladn/6RKVGs=",
+          "capabilities": [
+            "event:emit",
+            "scene:read",
+            "ui:render"
+          ]
+        },
+        "pen:pen": {
+          "workerUrl": "./pen/index.49e3f16d.js",
+          "integrity": "sha256-SePxbRm9teVrsUtO0ZB74oglL7mB6U3m3H4AOmf1JGw=",
+          "capabilities": [
+            "event:emit",
+            "host:message",
+            "scene:read",
+            "scene:update",
+            "ui:render"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## 背景 / なぜ
ワールドは mod を `modId:componentName` から算出し、URL から**無検証で fetch した生JSを Worker 実行**していた。完全性検証は皆無で、manifest の `capabilities` も配布者の自己申告をそのまま権限層へ渡していた。つまり **mod 公開者が同一 version のままバンドルを差し替えれば、承認済みワールドに任意コード注入・権限昇格ができる**。

このPRは **ワールド URL の provenance を信頼根**とし、mod 公開者を信頼しなくてよい状態にする（Subresource Integrity 相当）。

## やったこと（4コミット）

### 1. mod 完全性ロック（hash固定＋権限天井）
- `@ubichill/shared`: `ModLock` スキーマ（`sha256-<base64>` SRI で version/コードhash/capability天井を宣言）＋純粋ロジック `resolveLockedMod`/`requiresLock`（fetch/crypto 非依存＝Node単体テスト可能）。
- `scripts/build-workers.mjs`: 各 mod version に `lock.json` 断片（コードhash + manifest hash + 検出 capability）を出力。
- ロード時: version を lock で固定（最新ポインタを信頼しない）→ manifest/worker の生バイト列 hash を `crypto.subtle` で照合。**外部 provenance の不一致/lock欠落は実行拒否、local は寛容**。capability は verified 時のみ **lock 天井**を採用（manifest 申告を無視＝配布者による昇格を封殺）。

### 2. lock をワールドYAMLから分離（可読性）
人間が書く scene 定義と機械生成の hash を1ファイルに混ぜない。
- ubichillワールド: `worlds.lock` **DB別カラム**（migration 0003）→ 兄弟エンドポイント `GET /worlds/:id/lock` で配信。配信YAMLはクリーン。
- GitHub由来: 兄弟 `.lock.json`（`lockUrlFor` が導出、resolver が best-effort 取得）。
- 任意URL: `spec.lock` 埋め込みフォールバック。

### 3. `@ubichill/loader` 新設（frontend からロジック分離）
- ビルドレス・**React/DOM 非依存・browser+Node 両対応**・依存は `@ubichill/shared` のみ。`acquireMod`/`buildWorldLock`/`sriOf`（baseUrl・fetch 注入）。
- frontend の `modLoader`/`buildWorldLock` は薄いアダプタに縮小。`@ubichill/sandbox` は無改修（入力契約＝検証済み workerCode + capability 天井のみ）。

### 4. 汎用ロック生成CLI
- `pnpm gen:lock <world.yaml>` → 兄弟 `<world>.lock.json` 生成（fs / `--base-url` 切替）。GitHub 手書き作者も lock を作れる。`worlds/default.lock.json` 生成済み。
- ついでに pen の tsconfig paths から Host 内部を除去（mod は `@ubichill/sdk` のみ依存の原則を tsconfig でも担保）。

## 責務4層
知識=`shared` / 取得+検証+lock構築=`loader` / 状態+env解決=`frontend` / 隔離実行=`sandbox`。

## 検証
- 全パッケージ typecheck・`pnpm lint` クリーン、**205 tests（200 pass / 5 skip）**。
- frontend vite build 成功（loader をソース消費）。
- **ライブE2E**: `gen:lock` で default.lock.json 生成 → `/worlds/default/lock` 200・配信YAMLクリーン → 公式ワールド入室で pen×3・video-player×4 全 worker が初期化・lock拒否ゼロ（verified パス）。改竄バンドルは外部 provenance で拒否、manifest の権限過剰申告は lock 天井で無視——を Node harness と実ファイルで実証。

## 非対象（将来）
- assets（`Ubi.modBase` 遅延ロード）の hash 固定・lock 署名（作者鍵）・`ubi` CLI 統合。

🤖 Generated with [Claude Code](https://claude.com/claude-code)