### PR TITLE
refactor(build): capability検出をshared一本化＋build-workers CLIを汎用化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,8 +87,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # typecheck はパッケージ間参照が dist 経由のため、shared/db は事前ビルドが要る。
-      # vitest は resolve.alias でソースへ直結するため build 不要（DB統合テストも
-      # DATABASE_URL 未設定時は describe.skipIf で db import 自体をスキップする）。
+      # vitest 自体は resolve.alias で shared/ecs/sdk/ui-renderer/loader をソースへ直結するため
+      # build 不要（DB統合テストも DATABASE_URL 未設定時は describe.skipIf でスキップ）。
+      # ただし後段の build-workers.mjs は plain node 実行で @ubichill/shared を dist 経由で
+      # import するため、このステップがそれより前に無いと解決に失敗する。
       - name: Build shared & db
         run: |
           pnpm --filter @ubichill/shared build

--- a/.github/workflows/mods-pages.yml
+++ b/.github/workflows/mods-pages.yml
@@ -43,6 +43,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
+      # build-workers.mjs は capability 検出テーブルを @ubichill/shared から import するため、
+      # ビルド済み dist が先に無いと解決に失敗する。
+      - name: Build shared package
+        run: pnpm --filter @ubichill/shared build
+
       - name: Build mod workers
         # dist/mods/ に各modのバンドルが出力される
         run: pnpm build:workers

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "gen:lock": "tsx packages/loader/src/cli.ts",
     "verify:mod-locks": "node scripts/verify-mod-locks.mjs",
     "docs:capabilities": "node scripts/gen-capability-docs.mjs",
-    "build": "node scripts/build-workers.mjs && turbo build",
+    "build": "pnpm --filter @ubichill/shared build && node scripts/build-workers.mjs && turbo build",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
     "typecheck": "pnpm -r exec tsgo --noEmit",

--- a/packages/shared/src/mod/capability.test.ts
+++ b/packages/shared/src/mod/capability.test.ts
@@ -4,8 +4,10 @@ import {
     buildAllowedCommands,
     CAPABILITY_CATALOG,
     CAPABILITY_COMMANDS,
+    CAPABILITY_DETECTORS,
     CAPABILITY_RISK,
     describeCapability,
+    detectCapabilities,
     getCapabilityRisk,
     listCapabilities,
 } from './capability';
@@ -44,6 +46,71 @@ describe('CAPABILITY_CATALOG（単一の真実の源）', () => {
             expect(CAPABILITY_RISK[cap]).toBe(spec.risk);
         }
         expect(Object.keys(CAPABILITY_COMMANDS).sort()).toEqual(Object.keys(CAPABILITY_CATALOG).sort());
+    });
+});
+
+describe('CAPABILITY_DETECTORS（カタログとの drift-guard）', () => {
+    it('全 detector の cap は CAPABILITY_CATALOG に実在する（typo・削除漏れの検知）', () => {
+        const knownCaps = new Set(Object.keys(CAPABILITY_CATALOG));
+        for (const d of CAPABILITY_DETECTORS) {
+            expect(knownCaps.has(d.cap), `detector "${d.cap}" が CAPABILITY_CATALOG に存在しない`).toBe(true);
+        }
+    });
+
+    it('detectCapabilities が返す capability も必ずカタログに実在する', () => {
+        const knownCaps = new Set(Object.keys(CAPABILITY_CATALOG));
+        const detected = detectCapabilities('Ubi.fetch(); Ubi.ui.render(); Ubi.canvas.frame(); Ubi.media.play();');
+        for (const cap of detected) {
+            expect(knownCaps.has(cap), `detectCapabilities が未知の capability "${cap}" を返した`).toBe(true);
+        }
+    });
+});
+
+describe('detectCapabilities（Ubi API の静的検出）', () => {
+    it('Ubi.fetch から net:fetch を検出する', () => {
+        expect(detectCapabilities('const r = await Ubi.fetch("https://api.example.com");')).toContain('net:fetch');
+    });
+
+    it('Ubi.ui.render から ui:render を検出する', () => {
+        expect(detectCapabilities('Ubi.ui.render(() => <div/>);')).toContain('ui:render');
+    });
+
+    it('.showToast( から ui:toast を検出する', () => {
+        expect(detectCapabilities('Ubi.ui.showToast("hi");')).toContain('ui:toast');
+    });
+
+    it('Ubi.entity / Ubi.state から scene:read と scene:update を検出する（over-approx）', () => {
+        const caps = detectCapabilities('const e = Ubi.entity.self; Ubi.state.sync({});');
+        expect(caps).toContain('scene:read');
+        expect(caps).toContain('scene:update');
+    });
+
+    it('.broadcast( から event:broadcast、.sendToHost( から host:message を検出する', () => {
+        const caps = detectCapabilities('Ubi.event.broadcast("x", {}); Ubi.event.sendToHost("user:update", {});');
+        expect(caps).toContain('event:broadcast');
+        expect(caps).toContain('host:message');
+        expect(caps).toContain('event:emit');
+    });
+
+    it('Ubi.canvas → canvas:draw、Ubi.media → media:control', () => {
+        expect(detectCapabilities('Ubi.canvas.frame();')).toContain('canvas:draw');
+        expect(detectCapabilities('Ubi.media.play("t");')).toContain('media:control');
+    });
+
+    it('Ubi API を使わないコードは空配列を返す', () => {
+        expect(detectCapabilities('const x = 1 + 2; console.log(x);')).toEqual([]);
+    });
+
+    it('emit だけのmodは host-message / broadcast を申告しない（過剰にならない）', () => {
+        const caps = detectCapabilities('Ubi.event.emit("tick", {});');
+        expect(caps).toContain('event:emit');
+        expect(caps).not.toContain('event:broadcast');
+        expect(caps).not.toContain('host:message');
+    });
+
+    it('結果はソート済み・重複なし', () => {
+        const caps = detectCapabilities('Ubi.entity.self; Ubi.entity.query(); Ubi.ui.render();');
+        expect(caps).toEqual([...new Set(caps)].sort());
     });
 });
 

--- a/packages/shared/src/mod/capability.ts
+++ b/packages/shared/src/mod/capability.ts
@@ -125,6 +125,61 @@ export const CAPABILITY_CATALOG = {
 /** カタログに定義済みの capability 名。 */
 export type Capability = keyof typeof CAPABILITY_CATALOG;
 
+// ============================================================
+// capability 自動検出（静的解析）
+// ============================================================
+
+/**
+ * バンドル済み Worker コードから使用中の Ubi API を静的検出し、capability を推定する。
+ *
+ * これは **情報表示（マニフェスト）用の over-approximate な推定**であり、セキュリティ境界
+ * ではない。実際の enforcement は実行時ゲート + ユーザー承認（ModHostManager）で行われ、
+ * 検出漏れ（動的アクセス・完全な分割代入など）は実行時に必ず拾われる。よって過剰申告寄り。
+ *
+ * ここを CAPABILITY_CATALOG と同じファイルに置くのは、検出テーブルとカタログが別リポジトリ
+ * （build スクリプト側）に分散すると capability の追加・改名時に同期漏れが起きるため。
+ * `cap` は必ず CAPABILITY_CATALOG のキーでなければならない（capability.test.ts の
+ * drift-guard テストが検証する）。
+ */
+export interface CapabilityDetector {
+    /** 検出対象の capability。CAPABILITY_CATALOG のキーである必要がある。 */
+    readonly cap: string;
+    /** どの Ubi API を使うとこの capability が付くかの人間向けヒント（ドキュメント生成が参照）。 */
+    readonly api: string;
+    readonly test: (code: string) => boolean;
+}
+
+export const CAPABILITY_DETECTORS: readonly CapabilityDetector[] = [
+    { cap: 'net:fetch', api: 'Ubi.fetch', test: (c) => /\bUbi\.fetch\b/.test(c) },
+    { cap: 'ui:render', api: 'Ubi.ui.render', test: (c) => /\bUbi\.ui\b/.test(c) },
+    { cap: 'ui:toast', api: 'Ubi.ui.showToast', test: (c) => /\.showToast\s*\(/.test(c) },
+    // scene:read は entity/state を触れば付くベースライン。
+    {
+        cap: 'scene:read',
+        api: 'Ubi.entity.get / query, Ubi.state 読み取り',
+        test: (c) => /\bUbi\.(entity|state)\b/.test(c),
+    },
+    // scene:update は書き込み系 API（update/spawn/destroy/state.sync）を使うときだけ付く。
+    // 読み取り専用 mod に update 権限を過剰申告しないための絞り込み（依然 over-approx 寄り）。
+    {
+        cap: 'scene:update',
+        api: 'Ubi.entity().update/spawn/destroy, Ubi.state.sync 書き込み',
+        test: (c) => /\.(update|spawn|destroy|sync)\s*\(/.test(c),
+    },
+    { cap: 'event:emit', api: 'Ubi.event.emit', test: (c) => /\bUbi\.event\b/.test(c) },
+    { cap: 'event:broadcast', api: 'Ubi.event.broadcast', test: (c) => /\.broadcast\s*\(/.test(c) },
+    { cap: 'host:message', api: 'Ubi.event.sendToHost', test: (c) => /\.sendToHost\s*\(/.test(c) },
+    { cap: 'canvas:draw', api: 'Ubi.canvas.*', test: (c) => /\bUbi\.canvas\b/.test(c) },
+    { cap: 'media:control', api: 'Ubi.media.*', test: (c) => /\bUbi\.media\b/.test(c) },
+];
+
+/** バンドル済みコードから capability 一覧を検出する（ソート済み・重複なし）。 */
+export function detectCapabilities(code: string): string[] {
+    return CAPABILITY_DETECTORS.filter((d) => d.test(code))
+        .map((d) => d.cap)
+        .sort();
+}
+
 /** capability → 許可コマンド一覧（カタログ由来の派生ビュー）。 */
 export const CAPABILITY_COMMANDS: Readonly<Record<string, readonly string[]>> = Object.fromEntries(
     Object.entries(CAPABILITY_CATALOG).map(([cap, spec]) => [cap, spec.commands]),

--- a/scripts/build-workers.mjs
+++ b/scripts/build-workers.mjs
@@ -21,11 +21,16 @@
  *      → https://cdn.example.com/mods/video-player/v2.1.0/templates/manifest.json
  */
 
+import { CAPABILITY_DETECTORS, detectCapabilities } from '@ubichill/shared';
 import * as esbuild from 'esbuild';
 import { createHash } from 'node:crypto';
 import { copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
+
+// capability 検出テーブルは @ubichill/shared に一本化（CAPABILITY_CATALOG と同じファイル）。
+// ここから re-export し、既存の import 元（build-workers.test.mjs 等）との互換を保つ。
+export { CAPABILITY_DETECTORS, detectCapabilities };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
@@ -79,48 +84,6 @@ function listFilesRecursive(rootDir, currentDir = rootDir) {
         }
     }
     return out;
-}
-
-// ============================================================
-// capability 自動検出（静的解析）
-// ============================================================
-
-/**
- * バンドル済み Worker コードから使用中の Ubi API を静的検出し、capability を推定する。
- *
- * これは **情報表示（マニフェスト）用の over-approximate な推定**であり、セキュリティ境界
- * ではない。実際の enforcement は実行時ゲート + ユーザー承認（ModHostManager）で行われ、
- * 検出漏れ（動的アクセス・完全な分割代入など）は実行時に必ず拾われる。よって過剰申告寄り。
- *
- * capability 名は shared の CAPABILITY_CATALOG と一致させること
- * （packages/shared/src/mod/capability.ts）。
- */
-// api: どの Ubi API を使うとこの capability が付くかの人間向けヒント（ドキュメント生成が参照）。
-export const CAPABILITY_DETECTORS = [
-    { cap: 'net:fetch', api: 'Ubi.fetch', test: (c) => /\bUbi\.fetch\b/.test(c) },
-    { cap: 'ui:render', api: 'Ubi.ui.render', test: (c) => /\bUbi\.ui\b/.test(c) },
-    { cap: 'ui:toast', api: 'Ubi.ui.showToast', test: (c) => /\.showToast\s*\(/.test(c) },
-    // scene:read は entity/state を触れば付くベースライン。
-    { cap: 'scene:read', api: 'Ubi.entity.get / query, Ubi.state 読み取り', test: (c) => /\bUbi\.(entity|state)\b/.test(c) },
-    // scene:update は書き込み系 API（update/spawn/destroy/state.sync）を使うときだけ付く。
-    // 読み取り専用 mod に update 権限を過剰申告しないための絞り込み（依然 over-approx 寄り）。
-    {
-        cap: 'scene:update',
-        api: 'Ubi.entity().update/spawn/destroy, Ubi.state.sync 書き込み',
-        test: (c) => /\.(update|spawn|destroy|sync)\s*\(/.test(c),
-    },
-    { cap: 'event:emit', api: 'Ubi.event.emit', test: (c) => /\bUbi\.event\b/.test(c) },
-    { cap: 'event:broadcast', api: 'Ubi.event.broadcast', test: (c) => /\.broadcast\s*\(/.test(c) },
-    { cap: 'host:message', api: 'Ubi.event.sendToHost', test: (c) => /\.sendToHost\s*\(/.test(c) },
-    { cap: 'canvas:draw', api: 'Ubi.canvas.*', test: (c) => /\bUbi\.canvas\b/.test(c) },
-    { cap: 'media:control', api: 'Ubi.media.*', test: (c) => /\bUbi\.media\b/.test(c) },
-];
-
-/** バンドル済みコードから capability 一覧を検出する（ソート済み・重複なし）。 */
-export function detectCapabilities(code) {
-    return CAPABILITY_DETECTORS.filter((d) => d.test(code))
-        .map((d) => d.cap)
-        .sort();
 }
 
 /**
@@ -332,8 +295,14 @@ export async function buildWorker(modJsonPath, options = {}) {
  * 全modの index.json を作成する。
  * エディタ等でローカル利用可能modの一覧を取得するために使う。
  * 各エントリは { id, name, version, kinds[] } 形式（mod.json + バージョン付き manifest を集約）。
+ *
+ * @param options.publicModsDir / options.distModsDir は buildWorker と同じ注入。
+ *   結合テストや将来の外部CLIが実リポジトリを汚さず一時ディレクトリへ書けるようにする。
  */
-function writeModIndex(modJsonFiles) {
+function writeModIndex(modJsonFiles, options = {}) {
+    const publicModsDir = options.publicModsDir ?? join(root, 'packages', 'frontend', 'public', 'mods');
+    const distModsDirResolved = options.distModsDir ?? distModsDir;
+
     const entries = [];
     for (const modJsonPath of modJsonFiles) {
         const modJson = JSON.parse(readFileSync(modJsonPath, 'utf-8'));
@@ -353,16 +322,24 @@ function writeModIndex(modJsonFiles) {
         });
     }
     const json = JSON.stringify(entries, null, 2);
-    const publicIndexPath = join(root, 'packages', 'frontend', 'public', 'mods', 'index.json');
-    const distIndexPath = join(distModsDir, 'index.json');
+    const publicIndexPath = join(publicModsDir, 'index.json');
+    const distIndexPath = join(distModsDirResolved, 'index.json');
+    mkdirSync(publicModsDir, { recursive: true });
+    mkdirSync(distModsDirResolved, { recursive: true });
     writeFileSync(publicIndexPath, json, 'utf-8');
     writeFileSync(distIndexPath, json, 'utf-8');
     console.log(`📋 mod index: ${entries.length} entries → public/mods/index.json, dist/mods/index.json`);
 }
 
-async function main() {
+/**
+ * @param options.modsDir mod.json を探索するディレクトリ（既定: <root>/mods）。
+ * @param options.publicModsDir / options.distModsDir は buildWorker/writeModIndex に注入。
+ *   すべて既定値は現行のリポジトリ内固定パスと同じ（後方互換）。将来 mod を外部リポジトリに
+ *   切り出した際、そのリポジトリから `--mods-dir=` 等で指し示せるようにするための一般化。
+ */
+export async function buildAllWorkers(options = {}) {
     console.log('🔨 Building mod workers...');
-    const modsDir = join(root, 'mods');
+    const modsDir = options.modsDir ?? join(root, 'mods');
     const modJsonFiles = findModJsonFiles(modsDir);
 
     if (modJsonFiles.length === 0) {
@@ -371,13 +348,24 @@ async function main() {
     }
 
     for (const modJsonPath of modJsonFiles) {
-        await buildWorker(modJsonPath);
+        await buildWorker(modJsonPath, options);
     }
 
-    writeModIndex(modJsonFiles);
+    writeModIndex(modJsonFiles, options);
 
     console.log('🎉 All workers built.');
-    console.log(`📦 CDN 配布用: dist/mods/`);
+    console.log(`📦 CDN 配布用: ${options.distModsDir ?? distModsDir}`);
+}
+
+async function main() {
+    const argv = process.argv.slice(2);
+    const modsDirArg = argv.find((a) => a.startsWith('--mods-dir='));
+    const publicModsDirArg = argv.find((a) => a.startsWith('--public-mods-dir='));
+
+    await buildAllWorkers({
+        modsDir: modsDirArg ? join(root, modsDirArg.split('=')[1]) : undefined,
+        publicModsDir: publicModsDirArg ? join(root, publicModsDirArg.split('=')[1]) : undefined,
+    });
 }
 
 // スクリプトとして直接実行された場合のみ main() を走らせる。

--- a/scripts/build-workers.test.mjs
+++ b/scripts/build-workers.test.mjs
@@ -1,52 +1,18 @@
 import { createHash } from 'node:crypto';
+import { detectCapabilities as sharedDetectCapabilities } from '@ubichill/shared';
 import { describe, expect, it } from 'vitest';
 import { detectCapabilities, sriOf } from './build-workers.mjs';
 
-describe('detectCapabilities（Ubi API の静的検出）', () => {
-    it('Ubi.fetch から net:fetch を検出する', () => {
-        expect(detectCapabilities('const r = await Ubi.fetch("https://api.example.com");')).toContain('net:fetch');
+// capability 検出の詳細な振る舞いテストは shared 側（packages/shared/src/mod/capability.test.ts）
+// に一本化した。ここでは build-workers.mjs の re-export が正しく shared の実体に繋がっている
+// ことだけを確認する（重複テストによるメンテナンスコストを避ける）。
+describe('detectCapabilities（shared からの re-export）', () => {
+    it('build-workers.mjs の detectCapabilities は shared の実体そのもの', () => {
+        expect(detectCapabilities).toBe(sharedDetectCapabilities);
     });
 
-    it('Ubi.ui.render から ui:render を検出する', () => {
-        expect(detectCapabilities('Ubi.ui.render(() => <div/>);')).toContain('ui:render');
-    });
-
-    it('.showToast( から ui:toast を検出する', () => {
-        expect(detectCapabilities('Ubi.ui.showToast("hi");')).toContain('ui:toast');
-    });
-
-    it('Ubi.entity / Ubi.state から scene:read と scene:update を検出する（over-approx）', () => {
-        const caps = detectCapabilities('const e = Ubi.entity.self; Ubi.state.sync({});');
-        expect(caps).toContain('scene:read');
-        expect(caps).toContain('scene:update');
-    });
-
-    it('.broadcast( から event:broadcast、.sendToHost( から host:message を検出する', () => {
-        const caps = detectCapabilities('Ubi.event.broadcast("x", {}); Ubi.event.sendToHost("user:update", {});');
-        expect(caps).toContain('event:broadcast');
-        expect(caps).toContain('host:message');
-        expect(caps).toContain('event:emit');
-    });
-
-    it('Ubi.canvas → canvas:draw、Ubi.media → media:control', () => {
-        expect(detectCapabilities('Ubi.canvas.frame();')).toContain('canvas:draw');
-        expect(detectCapabilities('Ubi.media.play("t");')).toContain('media:control');
-    });
-
-    it('Ubi API を使わないコードは空配列を返す', () => {
-        expect(detectCapabilities('const x = 1 + 2; console.log(x);')).toEqual([]);
-    });
-
-    it('emit だけのmodは host-message / broadcast を申告しない（過剰にならない）', () => {
-        const caps = detectCapabilities('Ubi.event.emit("tick", {});');
-        expect(caps).toContain('event:emit');
-        expect(caps).not.toContain('event:broadcast');
-        expect(caps).not.toContain('host:message');
-    });
-
-    it('結果はソート済み・重複なし', () => {
-        const caps = detectCapabilities('Ubi.entity.self; Ubi.entity.query(); Ubi.ui.render();');
-        expect(caps).toEqual([...new Set(caps)].sort());
+    it('実際に検出も機能する（smoke）', () => {
+        expect(detectCapabilities('Ubi.fetch("https://x");')).toContain('net:fetch');
     });
 });
 


### PR DESCRIPTION
## 背景
将来 `mods/` を外部リポジトリに切り出し、`@ubichill/sdk` を npm 公開し、`ubichill build` のような独立CLIを作る計画がある。切り出す前に、モノレポ内に残る技術的負債を解消する（SDK公開準備の先行PR）。

## 変更
- **capability自動検出の一本化**: `CAPABILITY_DETECTORS`/`detectCapabilities` を `build-workers.mjs` から `packages/shared/src/mod/capability.ts`（`CAPABILITY_CATALOG` と同じファイル）へ移設。従来は「手動で同期して」というコメントだけで、追加・改名時の同期漏れをコードで検知できなかった。drift-guardテスト（全detectorの`cap`がCATALOGに実在するか）を追加。
- **build-workers CLIの汎用化**: `writeModIndex()` の出力先を `buildWorker` と同様に注入可能化。`main()` を `buildAllWorkers(options)` としてexportし、`--mods-dir=`/`--public-mods-dir=` CLI引数を追加（既定値は現行の固定パスのままで後方互換）。
- **ビルド順序の修正**: `build-workers.mjs` が `@ubichill/shared` のビルド済みdistに新たに依存するため、ルート `build` scriptと `mods-pages.yml` に `shared` の事前ビルドを追加。

## 検証
- 209 tests pass、typecheck/lint クリーン。
- 実ビルドで worker hash が変化しないことを確認（回帰なし）。
- 新CLI引数（`--mods-dir=`/`--public-mods-dir=`）を一時ディレクトリで動作確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)