### PR TITLE
fix(docker): deps stageにloader/ui-renderer package.jsonが無くビルド失敗

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,12 @@ COPY packages/bff/package.json            ./packages/bff/package.json
 COPY packages/db/package.json             ./packages/db/package.json
 COPY packages/ecs/package.json            ./packages/ecs/package.json
 COPY packages/frontend/package.json       ./packages/frontend/package.json
+COPY packages/loader/package.json         ./packages/loader/package.json
 COPY packages/react/package.json          ./packages/react/package.json
 COPY packages/sandbox/package.json        ./packages/sandbox/package.json
 COPY packages/sdk/package.json            ./packages/sdk/package.json
 COPY packages/shared/package.json         ./packages/shared/package.json
+COPY packages/ui-renderer/package.json    ./packages/ui-renderer/package.json
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --ignore-scripts
 


### PR DESCRIPTION
## Summary
- 本番Dockerビルドで `Cannot find package 'yaml' imported from /app/packages/loader/src/genLock.ts` で失敗していた
- 原因: `Dockerfile` の `deps` ステージが `package.json` を個別COPYする方式で、`packages/loader`（`packages/sdk/cli` 経由で `pnpm build:workers` が使うようになった）と `packages/ui-renderer` がリストから漏れていた
- 2ファイルの `package.json` COPY行を追加

## Test plan
- [x] 全workspaceパッケージ（11個）が Dockerfile の deps ステージに含まれることを確認
- [x] `pnpm test` / `pnpm typecheck` / `pnpm lint` すべてクリーン
- [ ] 実際のDocker buildでの動作確認（重いローカル検証はスキップ、CIで確認）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>