### PR TITLE
fix: release-sdk.ymlのnpm@latest強制インストールでEBADENGINE失敗を修正

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -72,10 +72,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # trusted publishing は npm CLI 11.5.1 以上が必須（実測: Node同梱npmが古いと
-      # OIDCトークン交換ロジック自体が存在せず、通常のトークン認証を要求されて失敗する）。
+      # npm@latest への強制アップグレードは Node の奇数(Current)ラインで EBADENGINE になるため行わない。
       - name: Ensure npm >= 11.5.1 (required for OIDC trusted publishing)
-        run: npm install -g npm@latest && npm --version
+        run: |
+          node -e '
+            const required = "11.5.1";
+            const current = require("node:child_process").execSync("npm --version").toString().trim();
+            const toParts = (v) => v.split(".").map(Number);
+            const [cm, cn, cp] = toParts(current);
+            const [rm, rn, rp] = toParts(required);
+            const ok = cm > rm || (cm === rm && (cn > rn || (cn === rn && cp >= rp)));
+            console.log(`npm ${current} (required >= ${required}): ${ok ? "OK" : "FAIL"}`);
+            if (!ok) process.exit(1);
+          '
 
       # sdk が実行時に inline する ecs/shared の最新ソースを確実に見る（型検証のため）。
       - name: Build shared package


### PR DESCRIPTION
## 概要
- `release-sdk.yml` の `npm install -g npm@latest && npm --version` が失敗していた（マージ後のCI実行で発生）。
- 原因: npmの最新メジャー（12系）が `engines.node` で Node の偶数（LTS）ラインしか許可しなくなっており、本リポジトリが `volta.node` で固定している Node 25.9.0（奇数=Currentライン）とは互換性が無く、強制インストール自体が `EBADENGINE` で失敗していた。
- 対応: そもそも Node 25.9.0 に同梱の npm（11.12.1）は、このステップが本来必要としている「OIDC trusted publishing に必要な npm >= 11.5.1」を既に満たしているため、`npm install -g npm@latest` をやめて、バージョンが要件を満たしているかを確認するだけのチェックに変更した。

## テスト
- [x] 変更したチェックスクリプトをローカルで実行し、`npm 11.12.1 (required >= 11.5.1): OK` になることを確認
- [x] YAML構文をパースして妥当性を確認
- [ ] 実際のCI（release-sdk.yml）が通ることを確認（このPRのCI実行 or 次回mainへのpush時）

🤖 Generated with [Claude Code](https://claude.com/claude-code)