### PR TITLE
fix: video-player:screenのconfigにcapabilitiesを明示

### DIFF
--- a/mods/video-player/src/screen.worker.tsx
+++ b/mods/video-player/src/screen.worker.tsx
@@ -14,6 +14,7 @@ export const config: ComponentConfig = {
     watchEntityTypes: [],
     watchScope: 'entity',
     defaultTransform: { x: 0, y: 0, z: 2, w: 640, h: 360 },
+    capabilities: ['event:emit', 'media:control'],
 };
 
 const TARGET = 'main';

--- a/worlds/default.lock.json
+++ b/worlds/default.lock.json
@@ -4,7 +4,7 @@
     "video-player": {
       "id": "video-player",
       "version": "2.0.0",
-      "manifestIntegrity": "sha256-dZErrhj7RaYR1MsCSyoPLLy6sG+DLE53ngjvKxu7H4Q=",
+      "manifestIntegrity": "sha256-4PwSrCeStG8umK93ZZfGdbeuheW1MAFw/NvKCQI7RN8=",
       "components": {
         "video-player:controls": {
           "workerUrl": "./controls/index.ef95e0fb.js",
@@ -27,8 +27,8 @@
           ]
         },
         "video-player:screen": {
-          "workerUrl": "./screen/index.3f09391e.js",
-          "integrity": "sha256-Pwk5HquUWNpdHZSIy2cT2wPoNvbtfdY+95t840tkKiA=",
+          "workerUrl": "./screen/index.9ba2bbc4.js",
+          "integrity": "sha256-m6K7xD82cmu+Uihj8a4PQnHablfTmyPhdOhHNJv+d30=",
           "capabilities": [
             "event:emit",
             "media:control"


### PR DESCRIPTION
## 概要
`video-player:screen` は `Ubi.media.*` / `VPEvents.emit`（内部で `Ubi.event.emit`）を使うが、`config.capabilities` を宣言していなかったため、ビルド毎に以下の警告が出ていた。

```
⚠️  [video-player:screen] 過剰検出: event:emit, media:control (config.capabilities に宣言なし)
```

manifest/lock自体はコード検出との和集合で既に正しい値になっていたので実害は無いが、宣言と実態を一致させて警告を止める。

## テスト
- [x] `pnpm build:workers` で警告が出ないことを確認
- [x] `worlds/default.lock.json` を再生成
- [x] `npx vitest run` / `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)