### PR TITLE
feat: mod毎のbaseUrl解決を追加（video-player外部化の前提）

### DIFF
--- a/packages/loader/src/acquireMod.test.ts
+++ b/packages/loader/src/acquireMod.test.ts
@@ -159,4 +159,26 @@ describe('acquireMod', () => {
         const r = await acquireMod('nocolon', { baseUrl: BASE, sourceKind: 'local', fetchImpl: fakeFetch({}) });
         expect(r).toBe('not-found');
     });
+
+    it('lock.baseUrl がある mod は既定の baseUrl ではなくそちらから取得する', async () => {
+        const OTHER = 'https://other-host.test/mods';
+        const otherWorkerUrlAbs = `${OTHER}/${MOD}/v${VER}/canvas/index.abc.js`;
+        const otherManifestUrlAbs = `${OTHER}/${MOD}/v${VER}/manifest.json`;
+
+        const lockWithBaseUrl: ModLock = { ...lock(), mods: { [MOD]: { ...lock().mods[MOD], baseUrl: OTHER } } };
+
+        const r = await acquireMod(TYPE, {
+            baseUrl: BASE, // これは使われないはず
+            lock: lockWithBaseUrl,
+            sourceKind: 'github',
+            fetchImpl: fakeFetch({
+                [otherManifestUrlAbs]: { body: manifestJson },
+                [otherWorkerUrlAbs]: { body: WORKER_CODE, contentType: 'text/javascript' },
+            }),
+        });
+        expect(typeof r === 'object' && 'workerCode' in r).toBe(true);
+        if (typeof r === 'object' && 'workerCode' in r) {
+            expect(r.modBase).toBe(`${OTHER}/${MOD}/v${VER}`);
+        }
+    });
 });

--- a/packages/loader/src/acquireMod.ts
+++ b/packages/loader/src/acquireMod.ts
@@ -40,7 +40,8 @@ interface FetchedManifest {
 }
 
 export interface AcquireModOptions {
-    /** mod のベース URL（例: `/mods` or 外部 CDN）。末尾スラッシュなし。 */
+    /** mod の既定ベース URL（例: `/mods` or 外部 CDN）。末尾スラッシュなし。lock 側に
+     * `baseUrl` があればそちらを優先する（mod 毎に別ホストから配布されている場合）。 */
     baseUrl: string;
     /** ワールドに焼かれた mod 完全性ロック（無い場合あり）。 */
     lock?: ModLock;
@@ -131,7 +132,7 @@ async function fetchWorkerBytes(workerUrl: string, entityType: string, f: FetchL
  * lock 天井、それ以外は manifest 由来。
  */
 export async function acquireMod(entityType: string, opts: AcquireModOptions): Promise<AcquireResult> {
-    const { baseUrl, lock, sourceKind } = opts;
+    const { lock, sourceKind } = opts;
     const f = opts.fetchImpl ?? defaultFetch;
 
     const colonIdx = entityType.indexOf(':');
@@ -142,6 +143,9 @@ export async function acquireMod(entityType: string, opts: AcquireModOptions): P
 
     // 外部 provenance で lock 記載が無いなら、fetch する前に拒否する。
     if (!lockEntry && requiresLock(sourceKind)) return { rejected: 'lock-missing' };
+
+    // この mod だけ別ホストから配布されている場合、lock.baseUrl を既定より優先する。
+    const baseUrl = lockEntry?.baseUrl ?? opts.baseUrl;
 
     // version は lock を最優先で固定（無ければ最新ポインタ）。
     const version = lockEntry?.version ?? (await fetchModIndex(baseUrl, modName, f))?.version;

--- a/packages/loader/src/genLock.test.ts
+++ b/packages/loader/src/genLock.test.ts
@@ -1,0 +1,107 @@
+/**
+ * runGenLock（`ubichill lock`）の per-mod ソース切り替えを検証する。
+ *
+ * dependencies[].source.type === 'url' の mod だけ、そのURLから個別取得し
+ * ModLockEntry.baseUrl に焼き込まれる（他ホストに配布された mod を acquireMod が
+ * 正しく見つけられるようにする）ことを確認する。それ以外の mod は従来通り
+ * --mods-dir 配下の fs から読む。
+ */
+import { createHash } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ModLock } from '@ubichill/shared';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { runGenLock } from './genLock';
+
+const REMOTE_BASE = 'https://cdn.example.test/mods';
+
+function sri(text: string): string {
+    return `sha256-${createHash('sha256').update(text).digest('base64')}`;
+}
+
+function lockEntryJson(id: string, version: string) {
+    return JSON.stringify({ id, version, manifestIntegrity: sri(`${id}@${version}`), components: {} });
+}
+
+describe('runGenLock', () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), 'ubichill-genlock-'));
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+        vi.unstubAllGlobals();
+    });
+
+    it('type: url の依存だけそのURLから取得し baseUrl を焼き込む。他は --mods-dir の fs から読む', async () => {
+        // ローカル mod（pen）: --mods-dir 配下に配置
+        const modsDir = join(dir, 'mods');
+        mkdirSync(join(modsDir, 'pen', 'v1.0.0'), { recursive: true });
+        writeFileSync(join(modsDir, 'pen', 'mod.json'), JSON.stringify({ id: 'pen', version: '1.0.0' }));
+        writeFileSync(join(modsDir, 'pen', 'v1.0.0', 'lock.json'), lockEntryJson('pen', '1.0.0'));
+
+        // リモート mod（video-player）: dependencies[].source.type = 'url' 経由で取得
+        vi.stubGlobal(
+            'fetch',
+            vi.fn(async (url: string) => {
+                if (url === `${REMOTE_BASE}/video-player/mod.json`) {
+                    return { ok: true, json: async () => ({ id: 'video-player', version: '2.0.0' }) };
+                }
+                if (url === `${REMOTE_BASE}/video-player/v2.0.0/lock.json`) {
+                    return { ok: true, json: async () => JSON.parse(lockEntryJson('video-player', '2.0.0')) };
+                }
+                return { ok: false, json: async () => null };
+            }),
+        );
+
+        const worldPath = join(dir, 'world.yaml');
+        writeFileSync(
+            worldPath,
+            [
+                'apiVersion: ubichill.com/v1alpha1',
+                'kind: World',
+                'metadata:',
+                '  name: test-world',
+                '  version: 1.0.0',
+                'spec:',
+                '  displayName: test',
+                '  dependencies:',
+                '    - name: video-player',
+                '      source:',
+                `        type: url`,
+                `        url: ${REMOTE_BASE}`,
+                '    - name: pen',
+                '      source:',
+                '        type: repository',
+                '        path: mods/pen',
+                '  initialEntities:',
+                '    - id: e1',
+                '      tags: []',
+                '      children: []',
+                '      transform: { x: 0, y: 0, z: 0, scale: 1, rotation: 0 }',
+                '      components:',
+                '        - data: {}',
+                '          type: video-player:screen',
+                '    - id: e2',
+                '      tags: []',
+                '      children: []',
+                '      transform: { x: 0, y: 0, z: 0, scale: 1, rotation: 0 }',
+                '      components:',
+                '        - data: {}',
+                '          type: pen:pen',
+            ].join('\n'),
+            'utf-8',
+        );
+
+        const outPath = join(dir, 'world.lock.json');
+        await runGenLock([worldPath, `--mods-dir=${modsDir}`, `--out=${outPath}`]);
+
+        const lock = JSON.parse(readFileSync(outPath, 'utf-8')) as ModLock;
+        expect(Object.keys(lock.mods).sort()).toEqual(['pen', 'video-player']);
+        expect(lock.mods['video-player'].baseUrl).toBe(REMOTE_BASE);
+        expect(lock.mods.pen.baseUrl).toBeUndefined();
+    });
+});

--- a/packages/loader/src/genLock.ts
+++ b/packages/loader/src/genLock.ts
@@ -5,9 +5,12 @@
  * 直接実行の入口は持たない（純粋なライブラリ関数）。CLI としての実行は
  * `packages/sdk/cli`（`ubichill lock` サブコマンド）に一本化されている。
  *
- * getLockEntry の transport:
- *   - 既定/`--mods-dir`: ローカルの mods ディレクトリ（`ubichill build` 出力）から fs 読取。
- *   - `--base-url`     : HTTP 取得（外部 CDN 上の mod を固定する場合）。
+ * getLockEntry の transport（mod 毎に切り替わる）:
+ *   - world YAML の `dependencies[].source` が `type: url` の mod        → その `url` から HTTP 取得
+ *     （`ModLockEntry.baseUrl` に焼き込み、実行時 acquireMod がその mod だけ別ホストから読む）。
+ *   - `--base-url` 指定時、上記以外の mod                                → その URL から HTTP 取得。
+ *   - それ以外（既定 / `--mods-dir`）                                    → ローカルの mods ディレクトリ
+ *     （`ubichill build` 出力）から fs 読取。
  */
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -53,7 +56,20 @@ export async function runGenLock(argv: string[]): Promise<void> {
     const modsDir = argValue(argv, 'mods-dir')
         ? resolve(argValue(argv, 'mods-dir') as string)
         : join(process.cwd(), 'mods');
-    const getLockEntry = baseUrl ? createHttpLockEntryGetter(baseUrl) : createFsLockEntryGetter(modsDir);
+    const defaultGetLockEntry = baseUrl ? createHttpLockEntryGetter(baseUrl) : createFsLockEntryGetter(modsDir);
+
+    // dependencies[].source.type === 'url' の mod だけ、そのURLから個別に取得し baseUrl を焼き込む。
+    const urlSourceByModId = new Map(
+        (def.spec.dependencies ?? [])
+            .filter((d) => d.source.type === 'url' && d.source.url)
+            .map((d) => [d.name, d.source.url as string]),
+    );
+    const getLockEntry: LockEntryGetter = async (modId) => {
+        const modUrl = urlSourceByModId.get(modId);
+        if (!modUrl) return defaultGetLockEntry(modId);
+        const entry = await createHttpLockEntryGetter(modUrl)(modId);
+        return entry ? { ...entry, baseUrl: modUrl } : null;
+    };
 
     const lock = await buildWorldLock(modIds, getLockEntry);
 

--- a/packages/shared/src/schemas/modLock.schema.ts
+++ b/packages/shared/src/schemas/modLock.schema.ts
@@ -50,6 +50,11 @@ export const ModLockEntrySchema = z.object({
     manifestIntegrity: IntegritySchema,
     /** `modId:componentName` → lock 済み Component。 */
     components: z.record(z.string(), ModLockComponentSchema).default({}),
+    /**
+     * この mod だけの取得元 URL（末尾スラッシュなし）。世界の他 mod と別ホストに
+     * 配布されている場合のみ設定する。未設定ならホスト側の既定 baseUrl を使う。
+     */
+    baseUrl: z.string().url().optional(),
 });
 
 export type ModLockEntry = z.infer<typeof ModLockEntrySchema>;


### PR DESCRIPTION
## 概要
video-player modを外部リポジトリ（`ubichill-videoplayer`）へ分離する作業の前提として、loaderにmod毎のbaseUrl解決を実装した。

### 発覚した問題
`worlds/*.yaml`の`dependencies[].source`（`type: repository/npm/url`）は**ランタイムで一切参照されていなかった**。実際のmod読み込みは`packages/frontend/src/mods/modLoader.ts`の`MOD_BASE_URL`という単一グローバル値を全modに対して使っており、mod毎に別ホストから読み込む仕組みがなかった。

### 変更内容
- `ModLockEntrySchema`に`baseUrl`（optional, URL）を追加（`packages/shared`）
- `ubichill lock`（`runGenLock`）が、world YAMLの`dependencies[].source.type === 'url'`の依存だけそのURLから個別に`mod.json`/`lock.json`を取得し、取得したentryに`baseUrl`を焼き込む。それ以外は従来通り`--mods-dir`のfsから読む
- `acquireMod`が`lockEntry.baseUrl`を既定の`baseUrl`より優先するように変更

これにより、lock（＝worldのprovenanceに焼き込まれる信頼根）自体が「このmodはどこから取得すべきか」を保持するようになり、世界の他modと別ホストに配布されたmodも安全に読み込めるようになる。

## テスト
- `packages/loader/src/acquireMod.test.ts`: `lock.baseUrl`があるmodは既定のbaseUrlではなくそちらから取得することを確認
- `packages/loader/src/genLock.test.ts`（新規）: `type: url`の依存だけそのURLから取得しbaseUrlが焼き込まれ、他は`--mods-dir`のfsから読まれることを確認
- `npx vitest run` 232 passed / `pnpm lint` / `pnpm typecheck` すべて通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)