### PR TITLE
chore: TypeScriptをnative-preview(tsgo)から正式版7.0.2へ移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "pnpm --filter @ubichill/shared build && pnpm build:workers && turbo build",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
-    "typecheck": "pnpm -r exec tsgo --noEmit",
+    "typecheck": "pnpm -r exec tsc --noEmit",
     "db:generate": "pnpm --filter @ubichill/db generate",
     "db:migrate": "pnpm --filter @ubichill/db migrate:dev",
     "clean": "pnpm --filter \"./packages/*\" clean",
@@ -33,7 +33,8 @@
     "overrides": {
       "esbuild": "0.28.0",
       "react": "^19.2.5",
-      "react-dom": "^19.2.5"
+      "react-dom": "^19.2.5",
+      "dts-bundle-generator>typescript": "^5.9.0"
     },
     "onlyBuiltDependencies": [
       "esbuild",
@@ -49,7 +50,6 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^22.13.4",
-    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
     "esbuild": "^0.28.0",
@@ -57,6 +57,7 @@
     "kill-port": "^2.0.1",
     "nodemon": "^3.1.11",
     "turbo": "^2.8.3",
+    "typescript": "^7.0.2",
     "vitest": "^4.1.10"
   }
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,7 @@
     "main": "dist/index.js",
     "scripts": {
         "dev": "wait-on ../shared/dist/.build_done && nodemon",
-        "build": "tsgo",
+        "build": "tsc",
         "start": "node dist/index.js",
         "clean": "rimraf dist",
         "lint": "biome lint .",

--- a/packages/bff/package.json
+++ b/packages/bff/package.json
@@ -6,7 +6,7 @@
     "main": "dist/index.js",
     "scripts": {
         "dev": "tsx watch src/index.ts",
-        "build": "tsgo",
+        "build": "tsc",
         "start": "node dist/index.js",
         "clean": "rimraf dist",
         "lint": "biome lint ."

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -21,7 +21,7 @@
     ],
     "scripts": {
         "dev": "docker compose up -d && drizzle-kit studio",
-        "build": "tsgo",
+        "build": "tsc",
         "clean": "rimraf dist",
         "lint": "biome check .",
         "lint:fix": "biome check --write .",

--- a/packages/sdk/build.dts.verify.mjs
+++ b/packages/sdk/build.dts.verify.mjs
@@ -15,7 +15,7 @@
  * ようにし、通常の `pnpm test`/開発ループを重くしない）。CI・リリース前検証で明示的に実行する:
  *   pnpm verify:sdk-types
  *
- * 注意: execFileSync で `node_modules/.bin/tsgo` を repo ルート基準の相対パスで呼ぶため、
+ * 注意: execFileSync で `node_modules/.bin/tsc` を repo ルート基準の相対パスで呼ぶため、
  * このファイル自体は packages/sdk/ 配下だが、実行は常に repo ルートから
  * （`pnpm verify:sdk-types` → `vitest run --config vitest.sdk-verify.config.ts`）想定。
  */
@@ -100,10 +100,10 @@ describe('統合検証: @ubichill/ecs・@ubichill/shared が存在しない環�
                     'utf-8',
                 );
 
-                const tsgoBin = join(process.cwd(), 'node_modules', '.bin', 'tsgo');
+                const tscBin = join(process.cwd(), 'node_modules', '.bin', 'tsc');
                 // 失敗時は execFileSync が非ゼロ終了で throw する。stdio 'pipe' でエラー本文を拾う。
                 expect(() =>
-                    execFileSync(tsgoBin, ['--noEmit', '-p', '.'], { cwd: tmp, stdio: 'pipe' }),
+                    execFileSync(tscBin, ['--noEmit', '-p', '.'], { cwd: tmp, stdio: 'pipe' }),
                 ).not.toThrow();
             } finally {
                 rmSync(tmp, { recursive: true, force: true });

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2025",
+    "target": "ESNext",
     "types": [
       "node"
     ],

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -39,8 +39,8 @@
         }
     },
     "scripts": {
-        "dev": "nodemon --watch src --ext ts --exec \"tsgo && node ../../scripts/touch.mjs dist/.build_done\"",
-        "build": "tsgo",
+        "dev": "nodemon --watch src --ext ts --exec \"tsc && node ../../scripts/touch.mjs dist/.build_done\"",
+        "build": "tsc",
         "clean": "rimraf dist"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   esbuild: 0.28.0
   react: ^19.2.5
   react-dom: ^19.2.5
+  dts-bundle-generator>typescript: ^5.9.0
 
 importers:
 
@@ -32,9 +33,6 @@ importers:
       '@types/node':
         specifier: ^22.13.4
         version: 22.19.7
-      '@typescript/native-preview':
-        specifier: 7.0.0-dev.20260421.2
-        version: 7.0.0-dev.20260421.2
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -56,6 +54,9 @@ importers:
       turbo:
         specifier: ^2.8.3
         version: 2.8.3
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@types/node@22.19.7)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.0.10(@types/node@22.19.7)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -131,10 +132,10 @@ importers:
         version: 6.1.2
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.19.7)(typescript@6.0.3)
+        version: 10.9.2(@types/node@22.19.7)(typescript@7.0.2)
       ts-node-dev:
         specifier: ^2.0.0
-        version: 2.0.0(@types/node@22.19.7)(typescript@6.0.3)
+        version: 2.0.0(@types/node@22.19.7)(typescript@7.0.2)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -247,7 +248,7 @@ importers:
     devDependencies:
       '@pandacss/dev':
         specifier: ^1.8.1
-        version: 1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+        version: 1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       '@types/lodash.throttle':
         specifier: ^4.1.9
         version: 4.1.9
@@ -361,7 +362,7 @@ importers:
         version: 6.1.2
       tsc-watch:
         specifier: ^7.2.0
-        version: 7.2.0(typescript@6.0.3)
+        version: 7.2.0(typescript@7.0.2)
 
   packages/ui-renderer:
     dependencies:
@@ -1481,44 +1482,125 @@ packages:
   '@types/whatwg-url@13.0.0':
     resolution: {integrity: sha512-N8WXpbE6Wgri7KUSvrmQcqrMllKZ9uxkYWMt+mCSGwNc0Hsw9VQTW7ApqI4XNrx6/SaM2QQJCzMPDEXE058s+Q==}
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm]
     os: [linux]
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [linux]
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
-
-  '@typescript/native-preview@7.0.0-dev.20260421.2':
-    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
-    hasBin: true
 
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
@@ -3709,9 +3791,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@6.0.3:
-    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   uint8array-extras@1.5.0:
@@ -4692,14 +4774,14 @@ snapshots:
       postcss-selector-parser: 7.1.1
       ts-pattern: 5.9.0
 
-  '@pandacss/dev@1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/dev@1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@pandacss/config': 1.8.1
       '@pandacss/logger': 1.8.1
-      '@pandacss/mcp': 1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
-      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
-      '@pandacss/postcss': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      '@pandacss/mcp': 1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
+      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
+      '@pandacss/postcss': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       '@pandacss/preset-base': 1.8.1
       '@pandacss/preset-panda': 1.8.1
       '@pandacss/shared': 1.8.1
@@ -4713,10 +4795,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@pandacss/extractor@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/extractor@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
       '@pandacss/shared': 1.8.1
-      ts-evaluator: 1.2.0(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      ts-evaluator: 1.2.0(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       ts-morph: 27.0.2
     transitivePeerDependencies:
       - jsdom
@@ -4743,12 +4825,12 @@ snapshots:
       '@pandacss/types': 1.8.1
       kleur: 4.1.5
 
-  '@pandacss/mcp@1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/mcp@1.8.1(hono@4.11.5)(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
       '@clack/prompts': 0.11.0
       '@modelcontextprotocol/sdk': 1.25.3(hono@4.11.5)(zod@4.4.3)
       '@pandacss/logger': 1.8.1
-      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       '@pandacss/token-dictionary': 1.8.1
       '@pandacss/types': 1.8.1
       zod: 4.4.3
@@ -4759,13 +4841,13 @@ snapshots:
       - supports-color
       - typescript
 
-  '@pandacss/node@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/node@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
       '@pandacss/config': 1.8.1
       '@pandacss/core': 1.8.1
       '@pandacss/generator': 1.8.1
       '@pandacss/logger': 1.8.1
-      '@pandacss/parser': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      '@pandacss/parser': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       '@pandacss/reporter': 1.8.1
       '@pandacss/shared': 1.8.1
       '@pandacss/token-dictionary': 1.8.1
@@ -4789,16 +4871,16 @@ snapshots:
       prettier: 3.2.5
       ts-morph: 27.0.2
       ts-pattern: 5.9.0
-      tsconfck: 3.1.6(typescript@6.0.3)
+      tsconfck: 3.1.6(typescript@7.0.2)
     transitivePeerDependencies:
       - jsdom
       - typescript
 
-  '@pandacss/parser@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/parser@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
       '@pandacss/config': 1.8.1
       '@pandacss/core': 1.8.1
-      '@pandacss/extractor': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      '@pandacss/extractor': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       '@pandacss/logger': 1.8.1
       '@pandacss/shared': 1.8.1
       '@pandacss/types': 1.8.1
@@ -4810,9 +4892,9 @@ snapshots:
       - jsdom
       - typescript
 
-  '@pandacss/postcss@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)':
+  '@pandacss/postcss@1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)':
     dependencies:
-      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3)
+      '@pandacss/node': 1.8.1(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2)
       postcss: 8.5.6
     transitivePeerDependencies:
       - jsdom
@@ -5067,36 +5149,65 @@ snapshots:
       '@types/webidl-conversions': 7.0.3
     optional: true
 
-  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-aix-ppc64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-darwin-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-darwin-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+  '@typescript/typescript-freebsd-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-freebsd-x64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-linux-arm64@7.0.2':
     optional: true
 
-  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+  '@typescript/typescript-linux-arm@7.0.2':
     optional: true
 
-  '@typescript/native-preview@7.0.0-dev.20260421.2':
-    optionalDependencies:
-      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
-      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
 
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@22.19.7)(esbuild@0.28.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
@@ -5554,7 +5665,7 @@ snapshots:
 
   dts-bundle-generator@9.5.1:
     dependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
       yargs: 17.7.2
 
   dunder-proto@1.0.1:
@@ -7029,12 +7140,12 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
-  ts-evaluator@1.2.0(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@6.0.3):
+  ts-evaluator@1.2.0(jsdom@29.1.1(@noble/hashes@2.2.0))(typescript@7.0.2):
     dependencies:
       ansi-colors: 4.1.3
       crosspath: 2.0.0
       object-path: 0.11.8
-      typescript: 6.0.3
+      typescript: 7.0.2
     optionalDependencies:
       jsdom: 29.1.1(@noble/hashes@2.2.0)
 
@@ -7043,7 +7154,7 @@ snapshots:
       '@ts-morph/common': 0.28.1
       code-block-writer: 13.0.3
 
-  ts-node-dev@2.0.0(@types/node@22.19.7)(typescript@6.0.3):
+  ts-node-dev@2.0.0(@types/node@22.19.7)(typescript@7.0.2):
     dependencies:
       chokidar: 3.6.0
       dynamic-dedupe: 0.3.0
@@ -7053,15 +7164,15 @@ snapshots:
       rimraf: 2.7.1
       source-map-support: 0.5.21
       tree-kill: 1.2.2
-      ts-node: 10.9.2(@types/node@22.19.7)(typescript@6.0.3)
+      ts-node: 10.9.2(@types/node@22.19.7)(typescript@7.0.2)
       tsconfig: 7.0.0
-      typescript: 6.0.3
+      typescript: 7.0.2
     transitivePeerDependencies:
       - '@swc/core'
       - '@swc/wasm'
       - '@types/node'
 
-  ts-node@10.9.2(@types/node@22.19.7)(typescript@6.0.3):
+  ts-node@10.9.2(@types/node@22.19.7)(typescript@7.0.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -7075,23 +7186,23 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 6.0.3
+      typescript: 7.0.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
   ts-pattern@5.9.0: {}
 
-  tsc-watch@7.2.0(typescript@6.0.3):
+  tsc-watch@7.2.0(typescript@7.0.2):
     dependencies:
       cross-spawn: 7.0.6
       node-cleanup: 2.1.2
       ps-tree: 1.2.0
       string-argv: 0.3.2
-      typescript: 6.0.3
+      typescript: 7.0.2
 
-  tsconfck@3.1.6(typescript@6.0.3):
+  tsconfck@3.1.6(typescript@7.0.2):
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 7.0.2
 
   tsconfig@7.0.0:
     dependencies:
@@ -7144,7 +7255,28 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  typescript@6.0.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   uint8array-extras@1.5.0: {}
 


### PR DESCRIPTION
## 概要
`@typescript/native-preview`（tsgoのプレビュー版）から、正式リリースされた `typescript@7.0.2` に切り替える。

## 発見した重大な互換性の問題
`typescript@7.0.2`（正式版）は `exports` が `./lib/version.cjs`（バージョン情報のみ）で、旧来の Compiler API（`ts.sys`, `ts.createProgram` 等）を一切公開していない（新しい `unstable/*` API群に置き換わっている）。

`packages/sdk` の SDK公開パッケージ用 `.d.ts` バンドルに使っている `dts-bundle-generator`（2024年4月から更新なし・TS7未対応）はこの旧APIに依存しているため、ルートの `typescript` を7系にすると壊れる（`Cannot read properties of undefined (reading 'getCurrentDirectory')`）。

`packages/sdk` 自体に `typescript@5.9` を devDependency として追加する方式は効果がなかった（`dts-bundle-generator` は自分の依存グループ内で解決するため、hoistされたルートの7系を先に見つけてしまう）。最終的に `pnpm.overrides` で `"dts-bundle-generator>typescript": "^5.9.0"` と指定し、`dts-bundle-generator` の依存木だけを5.9系に固定して分離した。

併せて、安定版 typescript（5.x系）は `target: "ES2025"` を認識しないため、`dts-bundle-generator` がパースする `packages/sdk/tsconfig.json` の `target` を `ESNext` に変更した（`noEmit` のtypecheck用tsconfigであり、esbuildの実際のビルドターゲットには影響しない）。

## 変更内容
- `package.json`: devDependency を `@typescript/native-preview` → `typescript@^7.0.2`、`typecheck` スクリプトを `tsgo` → `tsc` に変更
- `packages/{backend,bff,db,shared}/package.json`: `build`/`dev` スクリプトの `tsgo` → `tsc`
- `packages/sdk/build.dts.verify.mjs`: `node_modules/.bin/tsgo` → `tsc`
- `packages/sdk/tsconfig.json`: `target: ES2025` → `ESNext`
- `package.json`: `pnpm.overrides` に `"dts-bundle-generator>typescript": "^5.9.0"` を追加

## テスト
- `npx vitest run`: 232 passed（`packages/sdk/build.test.mjs` 含む）
- `pnpm lint` / `pnpm typecheck`（全パッケージで `tsc --noEmit` が通ることを確認）
- `pnpm build:sdk` → `dist-npm` の smoke test（`UbiSDK` export確認）→ `pnpm build:workers` → `cli.js verify` を手動で通し、CIの「Build & smoke-test npm publish package」ステップ相当が全て成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)