### PR TITLE
fix: dev.mjsの死んだvideo-playerヘルスチェックを削除

### DIFF
--- a/scripts/dev.mjs
+++ b/scripts/dev.mjs
@@ -88,49 +88,6 @@ async function main() {
         // Don't exit here, maybe we can run without mods or user can fix it
     }
 
-    // Mod port health check: 各modのバックエンドポートが正しく応答しているか検証する。
-    // Docker がポートを占有していても、ホスト側に別プロセスが先に bind していると
-    // Vite プロキシがそちらへ届いてしまうため、Content-Type で判定する。
-    //
-    // 初回起動は image build + uvicorn の cold start で数十秒かかるので、
-    // 1.5 秒間隔で最大 30 秒ポーリング (=20 回) する。
-    const modChecks = [
-        { name: 'video-player', url: 'http://localhost:8000/', expectedContentType: 'application/json' },
-    ];
-    const HEALTHCHECK_MAX_TRIES = 20;
-    const HEALTHCHECK_INTERVAL_MS = 1500;
-    for (const { name, url, expectedContentType } of modChecks) {
-        let lastError = '';
-        let lastContentType = '';
-        let succeeded = false;
-        for (let i = 0; i < HEALTHCHECK_MAX_TRIES; i++) {
-            try {
-                const res = await fetch(url);
-                lastContentType = res.headers.get('content-type') ?? '';
-                if (lastContentType.includes(expectedContentType)) {
-                    console.log(`[mod:${name}] バックエンド OK (${url})`);
-                    succeeded = true;
-                    break;
-                }
-                // Content-Type 不一致は別プロセス占有の可能性大 → 即報告 (リトライ不要)
-                console.warn(`\n⚠️  [mod:${name}] ポート競合の可能性があります`);
-                console.warn(`   ${url} が "${lastContentType}" を返しています（期待値: ${expectedContentType}）`);
-                console.warn(`   同じポートを使用している別プロセスを確認してください:`);
-                console.warn(`   lsof -i :${new URL(url).port || 80}\n`);
-                succeeded = true; // 警告は出したのでループは抜ける
-                break;
-            } catch (err) {
-                lastError = err instanceof Error ? err.message : String(err);
-                await new Promise(resolve => setTimeout(resolve, HEALTHCHECK_INTERVAL_MS));
-            }
-        }
-        if (!succeeded) {
-            console.warn(`\n⚠️  [mod:${name}] バックエンドに接続できません: ${url}`);
-            console.warn(`   ${HEALTHCHECK_MAX_TRIES * HEALTHCHECK_INTERVAL_MS / 1000}s 待っても応答なし (${lastError})`);
-            console.warn(`   Docker コンテナのログを確認: docker compose -f mods/${name}/docker-compose.yml logs\n`);
-        }
-    }
-
     // Cleanup function
     let isCleaning = false;
     const cleanup = () => {


### PR DESCRIPTION
## 概要
video-playerが外部リポジトリ（ubichill-videoplayer）に分離されたため、このモノレポでは
もうvideo-playerのbackendを起動しない。`scripts/dev.mjs`の`modChecks`にハードコードされた
`video-player`エントリ（`http://localhost:8000/`）は、何も立たないポートを毎回30秒ポーリング
してタイムアウト警告を出すだけの死んだコードになっていた。

`start-mods.mjs`呼び出し自体（`docker:up`/`docker:down`）は`mods/*/docker-compose.yml`を
自動探索する汎用機構で、現状（penのみ、backendなし）では何もしないだけの無害なコードなので
残す（将来backendを持つmodが増えたら再度使える）。

## テスト
- `node --check scripts/dev.mjs`
- `pnpm lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)