### PR TITLE
feat: ubichill buildがindex.json（レジストリ一覧）を自動生成する

### DIFF
--- a/.changeset/mods-index-json.md
+++ b/.changeset/mods-index-json.md
@@ -1,0 +1,10 @@
+---
+"@ubichill/sdk": minor
+---
+
+`ubichill build` が `index.json`（レジストリ一覧: `id`/`name`/`version`/`components`）を自動生成するようになった。
+
+- 単一mod（外部リポジトリ）: 自分自身を1件だけ含む配列を `distDir`/`publicDir` に出力する。World Editor の「レジストリ URL を追加」機能にそのまま渡せる。
+- モノレポの一括ビルド: 全 mod を集約した配列をバッチルートに出力する。
+
+`buildMod()` の戻り値が `void` から `{ id, name, version, components }`（`ModIndexEntry`）に変わった。

--- a/packages/sdk/cli/build.ts
+++ b/packages/sdk/cli/build.ts
@@ -305,8 +305,16 @@ function readPackageJson(modDir: string): { id: string; name: string; version: s
     return { id, name, version };
 }
 
+/** `index.json`（レジストリ一覧）の1エントリ。World Editor の「レジストリ URL を追加」機能が読む形。 */
+export interface ModIndexEntry {
+    id: string;
+    name: string;
+    version: string;
+    components: string[];
+}
+
 /** @param modDir mod のルートディレクトリへの絶対パス */
-export async function buildMod(modDir: string, options: BuildOptions = {}): Promise<void> {
+export async function buildMod(modDir: string, options: BuildOptions = {}): Promise<ModIndexEntry> {
     const { id, name, version } = readPackageJson(modDir);
     const { distDir, publicDir } = resolveDirs({ ...options, modDir });
 
@@ -452,6 +460,16 @@ export async function buildMod(modDir: string, options: BuildOptions = {}): Prom
     writeFileSync(join(distVersionDir, 'lock.json'), lock, 'utf-8');
     writeFileSync(join(publicVersionDir, 'lock.json'), lock, 'utf-8');
     console.log(`🔒 [${id}] lock.json (${Object.keys(lockComponents).length} components)`);
+
+    // ── index.json（この mod 単体をレジストリとして公開する）────────────
+    // World Editor の「レジストリ URL を追加」機能は index.json（一覧）を期待する。
+    // 外部 mod は単体でも「1件だけのレジストリ」として同じ形で公開できるようにする。
+    const indexEntry: ModIndexEntry = { id, name, version, components: Object.keys(versionedComponents) };
+    const indexJson = JSON.stringify([indexEntry], null, 2);
+    writeFileSync(join(distDir, 'index.json'), indexJson, 'utf-8');
+    writeFileSync(join(publicDir, 'index.json'), indexJson, 'utf-8');
+
+    return indexEntry;
 }
 
 /**
@@ -467,6 +485,7 @@ async function runBatchBuild(modsDirArg: string, args: string[]): Promise<void> 
     const distDir = argValue('--dist-dir=') ?? join(process.cwd(), 'dist', 'mods');
     const publicDir = argValue('--public-mods-dir=') ?? distDir;
 
+    const indexEntries: ModIndexEntry[] = [];
     for (const entry of readdirSync(modsDir, { withFileTypes: true })) {
         if (!entry.isDirectory()) continue;
         const modDir = join(modsDir, entry.name);
@@ -478,8 +497,17 @@ async function runBatchBuild(modsDirArg: string, args: string[]): Promise<void> 
         const modPublicDir = join(publicDir, id);
 
         console.log(`\n🔨 [${entry.name}] building...`);
-        await buildMod(modDir, { distDir: modDistDir, publicDir: modPublicDir });
+        indexEntries.push(await buildMod(modDir, { distDir: modDistDir, publicDir: modPublicDir }));
     }
+
+    // ── index.json（このモノレポが持つ全 mod のレジストリ一覧）───────────
+    // World Editor の「使用する mod」一覧はこの index.json（バッチのルート）を読む。
+    mkdirSync(distDir, { recursive: true });
+    mkdirSync(publicDir, { recursive: true });
+    const aggregateIndexJson = JSON.stringify(indexEntries, null, 2);
+    writeFileSync(join(distDir, 'index.json'), aggregateIndexJson, 'utf-8');
+    writeFileSync(join(publicDir, 'index.json'), aggregateIndexJson, 'utf-8');
+    console.log(`\n📇 index.json (${indexEntries.length} mods)`);
 }
 
 /**

--- a/packages/sdk/test/build-mod.test.ts
+++ b/packages/sdk/test/build-mod.test.ts
@@ -370,6 +370,28 @@ describe('buildMod（新規mod作成パイプライン）', () => {
         expect(distPointer).toEqual({ id: 'pointer', name: 'pointer', version: '1.0.0' });
         expect(publicPointer).toEqual(distPointer);
     });
+
+    it('index.json（1件だけのレジストリ）が distDir と publicDir の両方に出力される', async () => {
+        const fixture: ModFixture = {
+            packageJson: { name: '@ubichill/mod-registry', version: '1.0.0' },
+            files: {
+                'main.worker.ts': [
+                    'import type { ComponentConfig } from "@ubichill/sdk";',
+                    'export const config: ComponentConfig = {};',
+                ].join('\n'),
+            },
+        };
+
+        const { modDir, distDir, publicDir } = buildFixture(fixture);
+        const entry = await buildMod(modDir, { distDir, publicDir });
+
+        expect(entry).toEqual({ id: 'registry', name: 'registry', version: '1.0.0', components: ['registry:main'] });
+
+        const distIndex = JSON.parse(readFileSync(join(distDir, 'index.json'), 'utf-8'));
+        const publicIndex = JSON.parse(readFileSync(join(publicDir, 'index.json'), 'utf-8'));
+        expect(distIndex).toEqual([entry]);
+        expect(publicIndex).toEqual([entry]);
+    });
 });
 
 describe('runBuild（CLI エントリポイント: 単一mod repo vs モノレポの自動判別）', () => {
@@ -422,6 +444,36 @@ describe('runBuild（CLI エントリポイント: 単一mod repo vs モノレ�
             readFileSync(join(workspaceDir, 'dist', 'mods', 'sub-mod', 'v1.0.0', 'manifest.json'), 'utf-8'),
         );
         expect(manifest.id).toBe('sub-mod');
+    });
+
+    it('モノレポ一括ビルドでは全 mod を集約した index.json がバッチルートに出力される', async () => {
+        const workspaceDir = mkdtempSync(join(tmpdir(), 'ubichill-workspace-multi-'));
+        tmpDirs.push(workspaceDir);
+        writeFileSync(join(workspaceDir, 'package.json'), JSON.stringify({ name: 'workspace-root' }), 'utf-8');
+
+        for (const modName of ['alpha', 'beta']) {
+            const modDir = join(workspaceDir, 'mods', modName);
+            mkdirSync(join(modDir, 'src'), { recursive: true });
+            writeFileSync(
+                join(modDir, 'package.json'),
+                JSON.stringify({ name: `@ubichill/mod-${modName}`, version: '1.0.0' }),
+                'utf-8',
+            );
+            writeFileSync(
+                join(modDir, 'src', 'main.worker.ts'),
+                ['import type { ComponentConfig } from "@ubichill/sdk";', 'export const config: ComponentConfig = {};'].join(
+                    '\n',
+                ),
+                'utf-8',
+            );
+        }
+
+        process.chdir(workspaceDir);
+        await runBuild([]);
+
+        const index = JSON.parse(readFileSync(join(workspaceDir, 'dist', 'mods', 'index.json'), 'utf-8'));
+        expect(index.map((e) => e.id).sort()).toEqual(['alpha', 'beta']);
+        expect(index.find((e) => e.id === 'alpha').components).toEqual(['alpha:main']);
     });
 
     it('package.json が無く mods/ も無い場合はエラーを throw する', async () => {


### PR DESCRIPTION
## 概要
`packages/frontend/public/mods/index.json`（World Editorの「使用するmod」チェックボックス一覧・「レジストリ URL を追加」機能が読む）は、どのスクリプトからも自動生成されておらず、手書きで置かれた古いファイルだった（gitignore対象で追跡もされていない）。video-player外部化で `mods/video-player` を削除した際にこの古いファイルの該当エントリだけが取り残され、存在しないローカルパスを指す壊れた状態のままになっていた。これが「エディタからいつも通りmodを追加できない」不具合の直接原因。

さらに、外部mod repo（`ubichill build` の単一mod出力）は `mod.json` しか出力しないため、World Editorの「レジストリ URL を追加」機能（`index.json` 形式のリストを期待する）にそのまま渡せなかった。

## 変更内容
- `buildMod()`: 自分自身を1件だけ含む `index.json`（`[{id, name, version, components}]`）を `distDir`/`publicDir` に出力するようにした。外部単一mod repoでもそのままレジストリURLとして登録できる。戻り値を `void` から `ModIndexEntry` に変更。
- `runBatchBuild()`: 全modを集約した `index.json` をバッチルート（例: `dist/mods/index.json`、`packages/frontend/public/mods/index.json`）に出力する。モノレポの「ローカルmod一覧」機能が実際に動くようになる。
- changeset追加（`@ubichill/sdk` minor）

## 注意（別途対応が必要）
`ubichill-videoplayer` 側は既に `dist/index.json` を gh-pages のサイトルートにコピーするよう対応済みだが、現在npmで公開されている `ubichill@0.2.0` はこの `index.json` 生成に対応していないため、実際に使えるのは本PRがマージされ **SDKが新バージョンとしてpublishされた後**になる。

## テスト
- `packages/sdk/test/build-mod.test.ts` にテスト追加:
  - 単一mod: `index.json` が1件配列で dist/public 両方に出ることを確認
  - モノレポ一括ビルド: 複数modを集約した `index.json` がバッチルートに出ることを確認
- `npx vitest run`: 234 passed
- `pnpm lint` / `pnpm typecheck`: pass
- `pnpm build:workers` を実行し、実際に `packages/frontend/public/mods/index.json` が正しく再生成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)