### PR TITLE
refactor: dependencies.source.type を repository→local にリネーム、未使用path/npmを削除

### DIFF
--- a/packages/frontend/src/pages/world-editor/hooks/useAvailableMods.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useAvailableMods.ts
@@ -5,7 +5,7 @@ type Dependency = NonNullable<WorldDefinition['spec']['dependencies']>[number];
 
 /**
  * 利用可能modの 1 エントリ。
- * - ローカル: `repositoryPath` を持つ → dependencies の source.type='repository' に変換
+ * - ローカル（`sourceLabel === 'local'`）: dependencies の source.type='local' に変換
  * - リモート: `baseUrl` を持つ → dependencies の source.type='url' に変換
  */
 export interface AvailableMod {
@@ -14,11 +14,9 @@ export interface AvailableMod {
     version: string;
     /** Component 型 (`modId:componentName`) 一覧 */
     components: string[];
-    /** ローカルmodのみ */
-    repositoryPath?: string;
     /** リモート（レジストリ） */
     baseUrl?: string;
-    /** どこから来たか（UI 表示用） */
+    /** どこから来たか（UI 表示用。'local' ならこのインスタンスの mods-dir） */
     sourceLabel: string;
 }
 
@@ -27,7 +25,6 @@ interface RawIndexEntry {
     name?: string;
     version: string;
     components?: string[];
-    repositoryPath?: string;
     baseUrl?: string;
 }
 
@@ -52,7 +49,6 @@ async function fetchRegistry(url: string, sourceLabel: string): Promise<Availabl
                 name: e.name ?? e.id,
                 version: e.version,
                 components: e.components ?? [],
-                repositoryPath: e.repositoryPath,
                 // リモートエントリ baseUrl が無い場合は registry URL のディレクトリを採用
                 baseUrl: e.baseUrl ?? (sourceLabel === 'local' ? undefined : baseUrl),
                 sourceLabel,
@@ -120,12 +116,8 @@ export function useAvailableMods(registryUrls: string[]): {
  * AvailableMod から WorldDefinition の dependencies エントリを構築する。
  */
 export function modToDependency(p: AvailableMod): Dependency {
-    if (p.repositoryPath) {
-        return { name: p.id, source: { type: 'repository', path: p.repositoryPath } };
-    }
     if (p.baseUrl) {
         return { name: p.id, source: { type: 'url', url: p.baseUrl, version: p.version } };
     }
-    // フォールバック: name のみで repository
-    return { name: p.id, source: { type: 'repository', path: `mods/${p.id}` } };
+    return { name: p.id, source: { type: 'local' } };
 }

--- a/packages/frontend/src/pages/world-editor/hooks/useDefinition.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useDefinition.ts
@@ -25,7 +25,7 @@ function createInitialDefinition(): WorldDefinition {
                 worldSize: { width: 2000, height: 1500 },
             },
             dependencies: [
-                { name: 'pen', source: { type: 'repository', path: 'mods/pen' } },
+                { name: 'pen', source: { type: 'local' } },
                 {
                     name: 'video-player',
                     source: { type: 'url', url: 'https://p-nasimonan.github.io/ubichill-videoplayer' },

--- a/packages/shared/src/schemas/world.schema.test.ts
+++ b/packages/shared/src/schemas/world.schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { type WorldSource, WorldSourceKind, worldOriginDomain } from './world.schema';
+import { DependencySourceSchema, type WorldSource, WorldSourceKind, worldOriginDomain } from './world.schema';
 
 describe('worldOriginDomain', () => {
     it('ローカルは null（何も出さない）', () => {
@@ -32,5 +32,32 @@ describe('worldOriginDomain', () => {
             }),
         ).toBe('raw.githubusercontent.com');
         expect(worldOriginDomain({ kind: WorldSourceKind.Url, url: 'http://example.com/w.yaml' })).toBe('example.com');
+    });
+});
+
+describe('DependencySourceSchema', () => {
+    it('type: local をそのまま受け付ける', () => {
+        expect(DependencySourceSchema.parse({ type: 'local' })).toEqual({ type: 'local' });
+    });
+
+    it('type: url + url を受け付ける', () => {
+        expect(DependencySourceSchema.parse({ type: 'url', url: 'https://example.com/mods' })).toEqual({
+            type: 'url',
+            url: 'https://example.com/mods',
+        });
+    });
+
+    it('後方互換: 旧 type: repository は local に変換される（既存ワールドの読み込みを壊さない）', () => {
+        expect(DependencySourceSchema.parse({ type: 'repository', path: 'mods/pen' })).toEqual({ type: 'local' });
+    });
+
+    it('未知の余剰プロパティ（旧 path 等）は無視される', () => {
+        const parsed = DependencySourceSchema.parse({ type: 'local', path: 'mods/pen', extra: 'x' });
+        expect(parsed).not.toHaveProperty('path');
+        expect(parsed).not.toHaveProperty('extra');
+    });
+
+    it('type: npm は廃止済みで拒否される', () => {
+        expect(() => DependencySourceSchema.parse({ type: 'npm' })).toThrow();
     });
 });

--- a/packages/shared/src/schemas/world.schema.ts
+++ b/packages/shared/src/schemas/world.schema.ts
@@ -299,9 +299,15 @@ export const WorldPermissionsSchema = z.object({
 // World Dependencies（依存関係）
 // ============================================
 
+// `type` はビルド時にどこから mod を取得するかを表す:
+//  - 'local': このワールドをビルドする側のローカル mods ディレクトリから fs で解決する
+//    （モノレポ内 mod 用。`path` はビルド時に一切参照されない装飾的フィールドだったため廃止）。
+//  - 'url'  : 指定した URL から mod の lock.json 断片を個別に取得する（外部 mod 用。
+//    `ubichill lock` がここから `ModLockEntry.baseUrl` を焼き込む）。
+// 'repository'（旧名。'local' と同義）は既存ワールドの後方互換のためだけに読み取りを許可する
+// （新規に書き出す側は必ず 'local' を使う）。'npm' は実装されたことがないため廃止。
 export const DependencySourceSchema = z.object({
-    type: z.enum(['repository', 'npm', 'url']),
-    path: z.string().optional(),
+    type: z.enum(['local', 'url', 'repository']).transform((v) => (v === 'repository' ? 'local' : v)),
     url: z.string().url().optional(),
     version: z.string().optional(),
 });

--- a/worlds/default.yaml
+++ b/worlds/default.yaml
@@ -18,8 +18,7 @@ spec:
         url: https://p-nasimonan.github.io/ubichill-videoplayer
     - name: pen
       source:
-        path: mods/pen
-        type: repository
+        type: local
   initialEntities:
     - id: video-player
       tags: []


### PR DESCRIPTION
## 概要
前回の議論で合意した通り、`dependencies[].source` のスキーマを整理する。

- `path` はビルド時・ランタイムどこからも一切参照されていなかった（`ubichill lock` のfs解決は `--mods-dir` とmodIdだけで決まる。完全に装飾的なフィールド）
- `type: 'repository'` は「gitリポジトリ」を意味しているわけではなく、実態は「このビルドのローカルmods-dirからfsで解決する」なので `type: 'local'` に変更
- `type: 'npm'` は実装されたことが無いので削除

## 後方互換
既存ワールド（DBに保存済みのもの含む）が `type: 'repository'` のまま壊れないよう、`DependencySourceSchema` に `transform` を入れて旧 `'repository'` を読み込み時に `'local'` へ正規化する。新規に書き出す側（World Editor、`worlds/default.yaml`）は必ず `'local'` を使う。zodは非strictなので余剰の `path` プロパティも安全に無視される。

## 変更内容
- `packages/shared/src/schemas/world.schema.ts`: `DependencySourceSchema` 更新
- `packages/shared/src/schemas/world.schema.test.ts`: テスト追加（local/url/後方互換のrepository→local変換/余剰プロパティ無視/npm拒否）
- `packages/frontend/src/pages/world-editor/hooks/useAvailableMods.ts` / `useDefinition.ts`: `repositoryPath`/`path` 参照を削除

## テスト
- `npx vitest run`: 239 passed
- `pnpm lint` / `pnpm typecheck`: pass
- 実際に `pnpm dev` でdev serverを起動し、ブラウザで `worlds/default.yaml`（`type: local` に変更済み）を新規インスタンス作成→入室し、`pen`/`video-player`（外部リポジトリ経由）の全sandboxが問題なく初期化完了することを確認
- 旧スキーマで保存された既存インスタンス（`type: repository` を含む）も引き続き正常に読み込まれることを確認（デバッグ中に実際にこの状態で入室できた）

🤖 Generated with [Claude Code](https://claude.com/claude-code)