### PR TITLE
fix: publish.mjsが既に公開済みのバージョンへ毎回publishを試みる問題を修正

### DIFF
--- a/packages/sdk/publish.mjs
+++ b/packages/sdk/publish.mjs
@@ -25,6 +25,20 @@ const sdkDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(sdkDir, '..', '..');
 const dryRun = process.argv.includes('--dry-run');
 
+/** 指定バージョンが既にレジストリに公開済みか（`npm view` は該当バージョンが無いと非ゼロ終了する）。 */
+export function isAlreadyPublished(name, version) {
+    try {
+        const out = execFileSync('npm', ['view', `${name}@${version}`, 'version'], {
+            cwd: repoRoot,
+            encoding: 'utf-8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+        return out === version;
+    } catch {
+        return false;
+    }
+}
+
 async function main() {
     const { name, version } = JSON.parse(readFileSync(join(sdkDir, 'package.json'), 'utf-8'));
 
@@ -37,6 +51,15 @@ async function main() {
         throw new Error(
             `version mismatch: ${name}@${version}（ソース） != ${published.name}@${published.version}（dist-npm）`,
         );
+    }
+
+    // changesets/action は「pending changeset が無い」限り毎回このスクリプトを呼ぶため、
+    // sdk本体のバージョンを上げないREADME更新等（packages/sdk/**へのpush）でも実行される。
+    // すでに公開済みのバージョンへ npm publish すると常にエラーになるため、fail せず
+    // skip する（このバージョンのタグ/Releaseは直前の成功時に作成済みのはず）。
+    if (!dryRun && isAlreadyPublished(published.name, published.version)) {
+        console.log(`⏭️  ${published.name}@${published.version} は既に公開済み。npm publish をスキップする。`);
+        return;
     }
 
     if (dryRun) {
@@ -54,7 +77,10 @@ async function main() {
     }
 }
 
-main().catch((err) => {
-    console.error('❌ SDK publish failed:', err);
-    process.exit(1);
-});
+const isMain = process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+    main().catch((err) => {
+        console.error('❌ SDK publish failed:', err);
+        process.exit(1);
+    });
+}

--- a/packages/sdk/publish.test.mjs
+++ b/packages/sdk/publish.test.mjs
@@ -1,0 +1,21 @@
+import { execFileSync } from 'node:child_process';
+import { describe, expect, it, vi } from 'vitest';
+import { isAlreadyPublished } from './publish.mjs';
+
+// npm view <name>@<version> version は、そのバージョンが無いと非ゼロ終了する。
+// 実ネットワークを叩かずにこの分岐を確認する（execFileSync をモック）。
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn() }));
+
+describe('isAlreadyPublished', () => {
+    it('npm view が該当バージョンを返せば true', () => {
+        vi.mocked(execFileSync).mockReturnValue('0.3.0\n');
+        expect(isAlreadyPublished('ubichill', '0.3.0')).toBe(true);
+    });
+
+    it('npm view が throw する（未公開バージョン）なら false', () => {
+        vi.mocked(execFileSync).mockImplementation(() => {
+            throw new Error('npm ERR! 404');
+        });
+        expect(isAlreadyPublished('ubichill', '9.9.9')).toBe(false);
+    });
+});


### PR DESCRIPTION
## 概要
PR #143（`packages/sdk/README.md`を含む）マージ後、release-sdk.ymlが以下で失敗した:

```
npm error You cannot publish over the previously published versions: 0.3.0.
```

原因: `changesets/action`はpending changesetが無い限り毎回`publish: node packages/sdk/publish.mjs`を呼ぶ。sdkのバージョンを上げない変更（今回はREADMEの一文修正）でも`packages/sdk/**`へのpushとして扱われ実行される。`publish.mjs`はそのたびに無条件で`npm publish`していたため、既に公開済みのバージョンに対して必ず失敗していた。

## 修正内容
`isAlreadyPublished()`で`npm view <name>@<version> version`を叩き、レジストリに既にそのバージョンが存在するか確認する。存在すればnpm publishをskipする（該当バージョンのgit tag/GitHub Releaseは直前の成功時に作成済みのはずなので、`CHANGESETS_OUTPUT`への記録もskip）。

テストを追加（`execFileSync`をモックし、実際にnpmレジストリへ問い合わせない）。

**マージは急ぎません。レビューをお願いします。**

## テスト
- `packages/sdk/publish.test.mjs`（新規）
- `node publish.mjs --dry-run` を手元で実行し、既存の動作（build → dry-run表示）が壊れていないことを確認
- `npx vitest run` 241 passed / `pnpm lint` / `pnpm typecheck`: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)