### PR TITLE
fix: mod管理UIをSettingsタブからWorld Editorへ一本化

### DIFF
--- a/packages/frontend/src/components/hud/tabs/SettingsTab.tsx
+++ b/packages/frontend/src/components/hud/tabs/SettingsTab.tsx
@@ -1,16 +1,17 @@
 /**
- * SettingsTab — ユーザー設定画面。mod権限の管理 + 外部modレジストリの管理。
+ * SettingsTab — ユーザー設定画面。現状はmod権限の管理。
  *
  * - シールドレベル（なし / 確認 / 厳格な確認 / 拒否）を選ぶと、危険度ティアの既定が決まる。
  *   安全な権限は常に許可でユーザーには見せない（判断が不要なため）。
  * - modごとに記憶済みの許可/拒否を危険度つきで確認し、取り消す。
- * - 外部modレジストリの追加/削除/エクスポート/インポート（ModRegistrySection）。
+ *
+ * 外部modレジストリの管理は World Editor の ModSelector（RegistryUrlManager）に一本化した
+ * （ワールド作成/編集以外での利用がほぼ無いため。設定タブに置いても発見されにくい）。
  *
  * 権限状態は @ubichill/react の PermissionProvider（main.tsx でマウント）から取得する。
  */
 import { type CapabilityRisk, describeCapability, type TierMode, useUbiPermissions } from '@ubichill/react';
 import { css } from '@/styled-system/css';
-import { ModRegistrySection } from './ModRegistrySection';
 import { cardStyle, sectionHeading, tabPanel } from './shared';
 
 type ShieldLevelId = 'none' | 'standard' | 'strict' | 'block';
@@ -372,8 +373,6 @@ export function SettingsTab() {
                     </div>
                 )}
             </div>
-
-            <ModRegistrySection />
         </div>
     );
 }

--- a/packages/frontend/src/mods/buildWorldLock.ts
+++ b/packages/frontend/src/mods/buildWorldLock.ts
@@ -3,7 +3,12 @@
  *
  * 収集・取得・構築の中核は @ubichill/loader。ここは baseUrl（MOD_BASE_URL）を注入するだけ。
  */
-import { buildWorldLock as build, collectModIds, createHttpLockEntryGetter } from '@ubichill/loader';
+import {
+    buildWorldLock as build,
+    collectModIds,
+    createHttpLockEntryGetter,
+    type LockEntryGetter,
+} from '@ubichill/loader';
 import type { ModLock, WorldDefinition } from '@ubichill/shared';
 import { MOD_BASE_URL } from './modLoader';
 
@@ -14,7 +19,23 @@ import { MOD_BASE_URL } from './modLoader';
  */
 export async function buildWorldLock(definition: WorldDefinition): Promise<ModLock> {
     const modIds = collectModIds(definition.spec.initialEntities);
-    const lock = await build(modIds, createHttpLockEntryGetter(MOD_BASE_URL));
+    const defaultGetLockEntry = createHttpLockEntryGetter(MOD_BASE_URL);
+
+    // dependencies[].source.type === 'url' の mod だけ、そのURLから個別に取得し baseUrl を焼き込む
+    // （packages/loader/src/genLock.ts の CLI 側ロジックと同じパターン）。
+    const urlSourceByModId = new Map(
+        (definition.spec.dependencies ?? [])
+            .filter((d) => d.source.type === 'url' && d.source.url)
+            .map((d) => [d.name, d.source.url as string]),
+    );
+    const getLockEntry: LockEntryGetter = async (modId) => {
+        const modUrl = urlSourceByModId.get(modId);
+        if (!modUrl) return defaultGetLockEntry(modId);
+        const entry = await createHttpLockEntryGetter(modUrl)(modId);
+        return entry ? { ...entry, baseUrl: modUrl } : null;
+    };
+
+    const lock = await build(modIds, getLockEntry);
     const missing = modIds.filter((id) => !(id in lock.mods));
     if (missing.length > 0) {
         console.warn(

--- a/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
+++ b/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
@@ -65,14 +65,18 @@ export function WorldEditorPage() {
         [definition.spec.initialEntities],
     );
 
-    const handleSave = useCallback(() => {
-        if (!definition.spec.displayName.trim()) {
-            setError('表示名は必須です。「ワールド情報」から入力してください');
-            modals.openInfo();
+    // コントロールパネルの「作成/保存」: draft を definition へ適用しつつ、その draft を
+    // そのまま保存対象として渡す（setDefinition の反映は次の render まで届かないため）。
+    const handlePublish = useCallback(() => {
+        const draft = modals.infoDraft;
+        if (!draft) return;
+        if (!draft.spec.displayName.trim()) {
+            setError('表示名は必須です');
             return;
         }
-        void editorApi.save();
-    }, [definition.spec.displayName, editorApi, modals]);
+        modals.applyInfo();
+        void editorApi.save(draft);
+    }, [modals, editorApi]);
 
     if (isPending || !session) return <CenteredMessage text="読み込み中..." />;
     if (loading) return <CenteredMessage text="ワールドを読み込み中..." />;
@@ -109,9 +113,8 @@ export function WorldEditorPage() {
                     dirty={dirty}
                     snapEnabled={mobile.snapEnabled}
                     onToggleSnap={mobile.toggleSnap}
-                    onOpenInfo={modals.openInfo}
+                    onOpenControlPanel={modals.openInfo}
                     onOpenYaml={modals.openYaml}
-                    onSave={handleSave}
                     onDelete={isEdit ? editorApi.remove : undefined}
                     onCreateInstance={isEdit ? editorApi.createInstance : undefined}
                 />
@@ -248,12 +251,17 @@ export function WorldEditorPage() {
             <Modal
                 open={modals.openModal === 'info'}
                 onClose={modals.cancelInfo}
-                title="ワールド情報"
-                width="640px"
+                title="コントロールパネル"
+                width="960px"
                 footer={
                     <>
                         <ModalSecondaryButton onClick={modals.cancelInfo}>キャンセル</ModalSecondaryButton>
-                        <ModalPrimaryButton onClick={modals.applyInfo}>適用</ModalPrimaryButton>
+                        <ModalPrimaryButton
+                            onClick={handlePublish}
+                            disabled={editorApi.saving || !modals.infoDraft?.spec.displayName.trim()}
+                        >
+                            {editorApi.saving ? '保存中...' : isEdit ? '保存' : '作成'}
+                        </ModalPrimaryButton>
                     </>
                 }
             >

--- a/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
+++ b/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
@@ -16,6 +16,7 @@ import { MobileLeftHandle } from './components/MobileLeftHandle';
 import { MobileRightHandle } from './components/MobileRightHandle';
 import { Modal } from './components/Modal';
 import { ModalPrimaryButton, ModalSecondaryButton } from './components/ModalButtons';
+import { PanelSection } from './components/PanelSection';
 import { useAvailableEntityKinds } from './hooks/useAvailableEntityKinds';
 import { useDefinition } from './hooks/useDefinition';
 import { useEditorModals } from './hooks/useEditorModals';
@@ -116,7 +117,6 @@ export function WorldEditorPage() {
                     snapEnabled={mobile.snapEnabled}
                     onToggleSnap={mobile.toggleSnap}
                     onOpenControlPanel={() => modals.openControlPanel()}
-                    onDelete={isEdit ? editorApi.remove : undefined}
                     onCreateInstance={isEdit ? editorApi.createInstance : undefined}
                 />
             </div>
@@ -214,11 +214,7 @@ export function WorldEditorPage() {
             </DockSlot>
 
             <DockSlot area="bottom" mobileVisible={true}>
-                <EditorAssets
-                    kinds={kinds}
-                    loading={kindsLoading}
-                    modNames={(definition.spec.dependencies ?? []).map((d) => d.name)}
-                />
+                <EditorAssets kinds={kinds} loading={kindsLoading} dependencies={definition.spec.dependencies ?? []} />
             </DockSlot>
 
             {!mobile.leftOpen && <MobileLeftHandle onClick={mobile.openLeft} />}
@@ -286,6 +282,37 @@ export function WorldEditorPage() {
                         onChange={modals.changeYamlText}
                         onFileUpload={modals.uploadYamlFile}
                     />
+                )}
+
+                {isEdit && (
+                    <div className={css({ mt: '4' })}>
+                        <PanelSection title="Danger Zone" defaultOpen={false}>
+                            <p className={css({ fontSize: '13px', color: 'textMuted' })}>
+                                このワールドを削除します。この操作は取り消せません。
+                            </p>
+                            <button
+                                type="button"
+                                onClick={editorApi.remove}
+                                disabled={editorApi.saving}
+                                className={css({
+                                    alignSelf: 'flex-start',
+                                    padding: '8px 16px',
+                                    bg: 'errorBg',
+                                    color: 'errorText',
+                                    border: '1px solid',
+                                    borderColor: 'errorLight',
+                                    borderRadius: '8px',
+                                    fontSize: '13px',
+                                    fontWeight: '600',
+                                    cursor: 'pointer',
+                                    _disabled: { opacity: 0.5, cursor: 'not-allowed' },
+                                    _hover: { opacity: 0.9 },
+                                })}
+                            >
+                                このワールドを削除
+                            </button>
+                        </PanelSection>
+                    </div>
                 )}
             </Modal>
         </div>

--- a/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
+++ b/packages/frontend/src/pages/world-editor/WorldEditorPage.tsx
@@ -3,10 +3,12 @@ import { useNavigate, useParams } from 'react-router';
 import { useSession } from '@/lib/session';
 import { css } from '@/styled-system/css';
 import { EditorAssets } from './components/assets/EditorAssets';
+import { ControlPanelTabs } from './components/ControlPanelTabs';
 import { DockSlot } from './components/DockSlot';
 import { EditorHeader } from './components/EditorHeader';
 import { EditorStage } from './components/EditorStage';
-import { WorldInfoForm } from './components/forms/WorldInfoForm';
+import { ModSelector } from './components/forms/ModSelector';
+import { WorldPublishForm } from './components/forms/WorldPublishForm';
 import { YamlEditorForm } from './components/forms/YamlEditorForm';
 import { EditorHierarchy } from './components/hierarchy/EditorHierarchy';
 import { EntityInspector } from './components/inspector/EntityInspector';
@@ -68,13 +70,13 @@ export function WorldEditorPage() {
     // コントロールパネルの「作成/保存」: draft を definition へ適用しつつ、その draft を
     // そのまま保存対象として渡す（setDefinition の反映は次の render まで届かないため）。
     const handlePublish = useCallback(() => {
-        const draft = modals.infoDraft;
+        const draft = modals.draft;
         if (!draft) return;
         if (!draft.spec.displayName.trim()) {
             setError('表示名は必須です');
             return;
         }
-        modals.applyInfo();
+        modals.applyControlPanel();
         void editorApi.save(draft);
     }, [modals, editorApi]);
 
@@ -113,8 +115,7 @@ export function WorldEditorPage() {
                     dirty={dirty}
                     snapEnabled={mobile.snapEnabled}
                     onToggleSnap={mobile.toggleSnap}
-                    onOpenControlPanel={modals.openInfo}
-                    onOpenYaml={modals.openYaml}
+                    onOpenControlPanel={() => modals.openControlPanel()}
                     onDelete={isEdit ? editorApi.remove : undefined}
                     onCreateInstance={isEdit ? editorApi.createInstance : undefined}
                 />
@@ -249,49 +250,43 @@ export function WorldEditorPage() {
             )}
 
             <Modal
-                open={modals.openModal === 'info'}
-                onClose={modals.cancelInfo}
+                open={modals.open}
+                onClose={modals.closeControlPanel}
                 title="コントロールパネル"
                 width="960px"
                 footer={
                     <>
-                        <ModalSecondaryButton onClick={modals.cancelInfo}>キャンセル</ModalSecondaryButton>
+                        <ModalSecondaryButton onClick={modals.closeControlPanel}>キャンセル</ModalSecondaryButton>
                         <ModalPrimaryButton
                             onClick={handlePublish}
-                            disabled={editorApi.saving || !modals.infoDraft?.spec.displayName.trim()}
+                            disabled={editorApi.saving || !modals.draft?.spec.displayName.trim()}
                         >
                             {editorApi.saving ? '保存中...' : isEdit ? '保存' : '作成'}
                         </ModalPrimaryButton>
                     </>
                 }
             >
-                {modals.infoDraft && <WorldInfoForm draft={modals.infoDraft} onChange={modals.setInfoDraft} />}
-            </Modal>
-
-            <Modal
-                open={modals.openModal === 'yaml'}
-                onClose={modals.cancelYaml}
-                title="YAML 編集"
-                width="800px"
-                footer={
-                    <>
-                        <ModalSecondaryButton onClick={modals.cancelYaml}>キャンセル</ModalSecondaryButton>
-                        <ModalPrimaryButton
-                            onClick={modals.applyYaml}
-                            disabled={!!modals.yamlDraftError}
-                            title={modals.yamlDraftError || undefined}
-                        >
-                            適用
-                        </ModalPrimaryButton>
-                    </>
-                }
-            >
-                <YamlEditorForm
-                    yamlText={modals.yamlDraft}
-                    yamlDirty={!!modals.yamlDraftError}
-                    onChange={modals.changeYamlDraft}
-                    onFileUpload={modals.uploadYamlFile}
-                />
+                <ControlPanelTabs active={modals.activeTab} onChange={modals.switchTab} />
+                {modals.draft && modals.activeTab === 'publish' && (
+                    <WorldPublishForm draft={modals.draft} onChange={modals.setDraft} />
+                )}
+                {modals.draft && modals.activeTab === 'mods' && (
+                    <ModSelector
+                        definition={modals.draft}
+                        onUpdateSpec={(patch) => {
+                            const draft = modals.draft;
+                            if (draft) modals.setDraft({ ...draft, spec: { ...draft.spec, ...patch } });
+                        }}
+                    />
+                )}
+                {modals.activeTab === 'yaml' && (
+                    <YamlEditorForm
+                        yamlText={modals.yamlText}
+                        yamlDirty={!!modals.yamlError}
+                        onChange={modals.changeYamlText}
+                        onFileUpload={modals.uploadYamlFile}
+                    />
+                )}
             </Modal>
         </div>
     );

--- a/packages/frontend/src/pages/world-editor/components/ControlPanelTabs.tsx
+++ b/packages/frontend/src/pages/world-editor/components/ControlPanelTabs.tsx
@@ -1,0 +1,54 @@
+import { css } from '@/styled-system/css';
+import type { ControlPanelTab } from '../hooks/useEditorModals';
+
+const TABS: { id: ControlPanelTab; label: string }[] = [
+    { id: 'publish', label: 'ワールド公開' },
+    { id: 'mods', label: 'mod管理' },
+    { id: 'yaml', label: 'YAML' },
+];
+
+interface ControlPanelTabsProps {
+    active: ControlPanelTab;
+    onChange: (tab: ControlPanelTab) => void;
+}
+
+/** コントロールパネル内のタブ切り替え。 */
+export function ControlPanelTabs({ active, onChange }: ControlPanelTabsProps) {
+    return (
+        <div
+            className={css({
+                display: 'flex',
+                gap: '4px',
+                borderBottom: '1px solid',
+                borderColor: 'border',
+                mb: '4',
+            })}
+        >
+            {TABS.map((tab) => {
+                const isActive = active === tab.id;
+                return (
+                    <button
+                        key={tab.id}
+                        type="button"
+                        onClick={() => onChange(tab.id)}
+                        className={css({
+                            padding: '8px 14px',
+                            fontSize: '13px',
+                            fontWeight: '600',
+                            color: isActive ? 'primary' : 'textMuted',
+                            bg: 'transparent',
+                            border: 'none',
+                            borderBottom: '2px solid',
+                            borderColor: isActive ? 'primary' : 'transparent',
+                            cursor: 'pointer',
+                            marginBottom: '-1px',
+                            _hover: { color: 'text' },
+                        })}
+                    >
+                        {tab.label}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
+++ b/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
@@ -12,9 +12,8 @@ interface EditorHeaderProps {
     /** ON のときドラッグ / リサイズをグリッド + ワールド範囲で snap/clamp する */
     snapEnabled: boolean;
     onToggleSnap: () => void;
-    /** コントロールパネル（ワールド情報・mod管理・公開）を開く */
+    /** コントロールパネル（ワールド公開・mod管理・YAML）を開く */
     onOpenControlPanel: () => void;
-    onOpenYaml: () => void;
     onDelete?: () => void;
     /** 編集モードかつ未変更時に有効。クリックでこのワールドの新インスタンスを作成して参加する */
     onCreateInstance?: () => void;
@@ -29,7 +28,6 @@ export function EditorHeader({
     snapEnabled,
     onToggleSnap,
     onOpenControlPanel,
-    onOpenYaml,
     onDelete,
     onCreateInstance,
 }: EditorHeaderProps) {
@@ -96,10 +94,6 @@ export function EditorHeader({
                     <GridIcon />
                     スナップ
                 </button>
-                <button type="button" onClick={onOpenYaml} className={editorButton({ intent: 'secondary' })}>
-                    <FileIcon />
-                    YAML
-                </button>
                 {isEdit && onDelete && (
                     <button
                         type="button"
@@ -165,13 +159,6 @@ export function EditorHeader({
                             className={editorButton({ intent: 'menu', size: 'menu' })}
                         >
                             スナップ: {snapEnabled ? 'ON' : 'OFF'}
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => runMenuAction(onOpenYaml)}
-                            className={editorButton({ intent: 'menu', size: 'menu' })}
-                        >
-                            YAML
                         </button>
                         {isEdit && onDelete && (
                             <button
@@ -241,15 +228,6 @@ function InfoIcon() {
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
             <circle cx="12" cy="12" r="10" />
             <path d="M12 16v-4M12 8h.01" />
-        </svg>
-    );
-}
-
-function FileIcon() {
-    return (
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
-            <path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" />
         </svg>
     );
 }

--- a/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
+++ b/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
@@ -12,9 +12,8 @@ interface EditorHeaderProps {
     /** ON のときドラッグ / リサイズをグリッド + ワールド範囲で snap/clamp する */
     snapEnabled: boolean;
     onToggleSnap: () => void;
-    /** コントロールパネル（ワールド公開・mod管理・YAML）を開く */
+    /** コントロールパネル（ワールド公開・mod管理・YAML）を開く。削除はコントロールパネル最下部のDanger Zoneへ移した */
     onOpenControlPanel: () => void;
-    onDelete?: () => void;
     /** 編集モードかつ未変更時に有効。クリックでこのワールドの新インスタンスを作成して参加する */
     onCreateInstance?: () => void;
 }
@@ -28,7 +27,6 @@ export function EditorHeader({
     snapEnabled,
     onToggleSnap,
     onOpenControlPanel,
-    onDelete,
     onCreateInstance,
 }: EditorHeaderProps) {
     const navigate = useNavigate();
@@ -94,16 +92,6 @@ export function EditorHeader({
                     <GridIcon />
                     スナップ
                 </button>
-                {isEdit && onDelete && (
-                    <button
-                        type="button"
-                        onClick={onDelete}
-                        disabled={saving}
-                        className={editorButton({ intent: 'danger' })}
-                    >
-                        削除
-                    </button>
-                )}
                 <button
                     type="button"
                     onClick={onOpenControlPanel}
@@ -160,16 +148,6 @@ export function EditorHeader({
                         >
                             スナップ: {snapEnabled ? 'ON' : 'OFF'}
                         </button>
-                        {isEdit && onDelete && (
-                            <button
-                                type="button"
-                                onClick={() => runMenuAction(onDelete)}
-                                disabled={saving}
-                                className={editorButton({ intent: 'menuDanger', size: 'menu' })}
-                            >
-                                削除
-                            </button>
-                        )}
                         <button
                             type="button"
                             onClick={() => runMenuAction(onOpenControlPanel)}

--- a/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
+++ b/packages/frontend/src/pages/world-editor/components/EditorHeader.tsx
@@ -12,9 +12,9 @@ interface EditorHeaderProps {
     /** ON のときドラッグ / リサイズをグリッド + ワールド範囲で snap/clamp する */
     snapEnabled: boolean;
     onToggleSnap: () => void;
-    onOpenInfo: () => void;
+    /** コントロールパネル（ワールド情報・mod管理・公開）を開く */
+    onOpenControlPanel: () => void;
     onOpenYaml: () => void;
-    onSave: () => void;
     onDelete?: () => void;
     /** 編集モードかつ未変更時に有効。クリックでこのワールドの新インスタンスを作成して参加する */
     onCreateInstance?: () => void;
@@ -28,9 +28,8 @@ export function EditorHeader({
     dirty,
     snapEnabled,
     onToggleSnap,
-    onOpenInfo,
+    onOpenControlPanel,
     onOpenYaml,
-    onSave,
     onDelete,
     onCreateInstance,
 }: EditorHeaderProps) {
@@ -42,9 +41,6 @@ export function EditorHeader({
         setMenuOpen(false);
         action();
     }, []);
-
-    const saveLabel = saving ? '保存中...' : isEdit ? '保存' : '作成';
-    const saveDisabled = saving || (isEdit && !dirty);
 
     return (
         <header
@@ -100,10 +96,6 @@ export function EditorHeader({
                     <GridIcon />
                     スナップ
                 </button>
-                <button type="button" onClick={onOpenInfo} className={editorButton({ intent: 'secondary' })}>
-                    <InfoIcon />
-                    ワールド情報
-                </button>
                 <button type="button" onClick={onOpenYaml} className={editorButton({ intent: 'secondary' })}>
                     <FileIcon />
                     YAML
@@ -120,12 +112,11 @@ export function EditorHeader({
                 )}
                 <button
                     type="button"
-                    onClick={onSave}
-                    disabled={saveDisabled}
-                    title={isEdit && !dirty ? '未変更' : undefined}
+                    onClick={onOpenControlPanel}
                     className={editorButton({ intent: 'primary', size: 'lg' })}
                 >
-                    {saveLabel}
+                    <InfoIcon />
+                    コントロールパネル
                 </button>
                 {isEdit && !dirty && onCreateInstance && (
                     <button
@@ -177,13 +168,6 @@ export function EditorHeader({
                         </button>
                         <button
                             type="button"
-                            onClick={() => runMenuAction(onOpenInfo)}
-                            className={editorButton({ intent: 'menu', size: 'menu' })}
-                        >
-                            ワールド情報
-                        </button>
-                        <button
-                            type="button"
                             onClick={() => runMenuAction(onOpenYaml)}
                             className={editorButton({ intent: 'menu', size: 'menu' })}
                         >
@@ -201,12 +185,10 @@ export function EditorHeader({
                         )}
                         <button
                             type="button"
-                            onClick={() => runMenuAction(onSave)}
-                            disabled={saveDisabled}
-                            title={isEdit && !dirty ? '未変更' : undefined}
+                            onClick={() => runMenuAction(onOpenControlPanel)}
                             className={editorButton({ intent: 'menuPrimary', size: 'menu' })}
                         >
-                            {saveLabel}
+                            コントロールパネル
                         </button>
                         {isEdit && !dirty && onCreateInstance && (
                             <button

--- a/packages/frontend/src/pages/world-editor/components/PanelSection.tsx
+++ b/packages/frontend/src/pages/world-editor/components/PanelSection.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { css } from '@/styled-system/css';
+
+interface PanelSectionProps {
+    title: string;
+    children: React.ReactNode;
+    defaultOpen?: boolean;
+}
+
+/**
+ * コントロールパネル内で使う、折りたたみ可能なセクション（ヘッダーバー + ▼トグル）。
+ * VRChat SDK Builder パネル風の見た目に寄せるための共通部品。
+ */
+export function PanelSection({ title, children, defaultOpen = true }: PanelSectionProps) {
+    const [open, setOpen] = useState(defaultOpen);
+
+    return (
+        <div
+            className={css({
+                border: '1px solid',
+                borderColor: 'border',
+                borderRadius: '10px',
+                overflow: 'hidden',
+            })}
+        >
+            <button
+                type="button"
+                onClick={() => setOpen((prev) => !prev)}
+                className={css({
+                    width: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '6px',
+                    padding: '8px 12px',
+                    bg: 'surfaceAccent',
+                    border: 'none',
+                    borderBottom: open ? '1px solid' : 'none',
+                    borderColor: 'border',
+                    fontSize: '13px',
+                    fontWeight: '700',
+                    color: 'text',
+                    cursor: 'pointer',
+                    textAlign: 'left',
+                    _hover: { bg: 'surfaceHover' },
+                })}
+            >
+                <span
+                    className={css({
+                        display: 'inline-block',
+                        transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+                        transition: 'transform 0.12s ease',
+                        fontSize: '10px',
+                        color: 'textMuted',
+                    })}
+                >
+                    ▼
+                </span>
+                {title}
+            </button>
+            {open && (
+                <div className={css({ padding: '12px', display: 'flex', flexDirection: 'column', gap: '4' })}>
+                    {children}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/frontend/src/pages/world-editor/components/assets/EditorAssets.tsx
+++ b/packages/frontend/src/pages/world-editor/components/assets/EditorAssets.tsx
@@ -1,14 +1,17 @@
+import type { WorldDefinition } from '@ubichill/shared';
 import { Fragment, type ReactNode, useMemo, useState } from 'react';
 import { css } from '@/styled-system/css';
 import type { AvailableEntityKind } from '../../hooks/useAvailableEntityKinds';
 import { type AssetNode, useModAssets } from '../../hooks/useModAssets';
 import { COMPONENT_DRAG_MIME } from '../../lib/dnd';
 
+type Dependency = NonNullable<WorldDefinition['spec']['dependencies']>[number];
+
 interface EditorAssetsProps {
     kinds: AvailableEntityKind[];
     loading: boolean;
-    /** YAML の dependencies で参照されているmod名一覧 */
-    modNames: string[];
+    /** YAML の dependencies（アセット取得先の per-mod base URL 解決に使う） */
+    dependencies: Dependency[];
 }
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg|avif)$/i;
@@ -18,8 +21,9 @@ const VIDEO_EXT = /\.(mp4|webm|mov)$/i;
 /** ナビゲーション位置: [] = ルート（mod一覧）、[mod, ...folder] = 中。 */
 type Path = string[];
 
-export function EditorAssets({ kinds, loading, modNames }: EditorAssetsProps) {
-    const { treesByMod } = useModAssets(modNames);
+export function EditorAssets({ kinds, loading, dependencies }: EditorAssetsProps) {
+    const { treesByMod } = useModAssets(dependencies);
+    const modNames = useMemo(() => dependencies.map((d) => d.name), [dependencies]);
     const [path, setPath] = useState<Path>([]);
 
     const componentsByMod = useMemo(() => {

--- a/packages/frontend/src/pages/world-editor/components/forms/ModSelector.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/ModSelector.tsx
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import { type AvailableMod, modToDependency, useAvailableMods } from '@/lib/mods/useAvailableMods';
 import { SETTINGS_KEYS, useSetting } from '@/lib/settings';
 import { css } from '@/styled-system/css';
+import { PanelSection } from '../PanelSection';
 import { RegistryUrlManager } from './RegistryUrlManager';
 
 const isStringArray = (value: unknown): value is string[] =>
@@ -44,155 +45,152 @@ export function ModSelector({ definition, onUpdateSpec }: ModSelectorProps) {
 
     return (
         <div className={css({ display: 'flex', flexDirection: 'column', gap: '3' })}>
-            <span className={css({ fontSize: '13px', fontWeight: '600', color: 'text' })}>
-                使用するmod
-                {loading && (
-                    <span className={css({ ml: '2', color: 'textSubtle', fontWeight: '400' })}>(読み込み中...)</span>
-                )}
-            </span>
-
-            {/* mod一覧（チェックボックス） */}
-            <div
-                className={css({
-                    display: 'grid',
-                    gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
-                    gap: '8px',
-                })}
-            >
-                {mods.map((p) => {
-                    const checked = checkedNames.has(p.id);
-                    return (
-                        <button
-                            type="button"
-                            key={`${p.sourceLabel}:${p.id}`}
-                            onClick={() => handleToggle(p)}
-                            className={css({
-                                display: 'flex',
-                                alignItems: 'flex-start',
-                                gap: '8px',
-                                p: '10px 12px',
-                                bg: checked ? 'primarySubtle' : 'background',
-                                border: '1.5px solid',
-                                borderColor: checked ? 'primary' : 'border',
-                                borderRadius: '10px',
-                                textAlign: 'left',
-                                cursor: 'pointer',
-                                _hover: { borderColor: 'borderStrong' },
-                            })}
-                        >
-                            <span
-                                className={css({
-                                    flexShrink: 0,
-                                    width: '16px',
-                                    height: '16px',
-                                    borderRadius: '4px',
-                                    border: '2px solid',
-                                    borderColor: checked ? 'primary' : 'border',
-                                    bg: checked ? 'primary' : 'transparent',
-                                    color: 'textOnPrimary',
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'center',
-                                    mt: '2px',
-                                })}
-                            >
-                                {checked && (
-                                    <svg
-                                        width="10"
-                                        height="10"
-                                        viewBox="0 0 12 12"
-                                        fill="none"
-                                        stroke="currentColor"
-                                        strokeWidth="2"
-                                    >
-                                        <path d="M2 6l3 3 5-6" />
-                                    </svg>
-                                )}
-                            </span>
-                            <div className={css({ flex: 1, minWidth: 0 })}>
-                                <div
-                                    className={css({
-                                        fontSize: '14px',
-                                        fontWeight: '600',
-                                        color: 'text',
-                                    })}
-                                >
-                                    {p.name}
-                                </div>
-                                <div className={css({ fontSize: '11px', color: 'textSubtle', mt: '2px' })}>
-                                    v{p.version} · {p.components.length} components
-                                </div>
-                                <div
-                                    className={css({
-                                        fontSize: '10px',
-                                        color: 'textSubtle',
-                                        mt: '2px',
-                                        opacity: 0.8,
-                                    })}
-                                >
-                                    {p.sourceLabel === 'local' ? 'ローカル' : p.sourceLabel}
-                                </div>
-                            </div>
-                        </button>
-                    );
-                })}
-                {!loading && mods.length === 0 && (
-                    <div className={css({ fontSize: '13px', color: 'textMuted', p: '12px' })}>
-                        利用可能なmodが見つかりません
-                    </div>
-                )}
-            </div>
-
-            {/* 未知のmod（YAML で直接追加されたもの） */}
-            {unknownDeps.length > 0 && (
+            <PanelSection title={loading ? '使用するmod (読み込み中...)' : '使用するmod'}>
+                {/* mod一覧（チェックボックス） */}
                 <div
                     className={css({
-                        bg: 'background',
-                        border: '1px dashed',
-                        borderColor: 'border',
-                        borderRadius: '10px',
-                        p: '10px 12px',
-                        display: 'flex',
-                        flexDirection: 'column',
-                        gap: '4px',
+                        display: 'grid',
+                        gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+                        gap: '8px',
                     })}
                 >
-                    <span className={css({ fontSize: '11px', color: 'textSubtle', fontWeight: '600' })}>
-                        その他の依存（未知のmod）
-                    </span>
-                    {unknownDeps.map((d) => (
-                        <div
-                            key={d.name}
-                            className={css({
-                                display: 'flex',
-                                alignItems: 'center',
-                                justifyContent: 'space-between',
-                                fontSize: '13px',
-                                color: 'text',
-                            })}
-                        >
-                            <span>{d.name}</span>
+                    {mods.map((p) => {
+                        const checked = checkedNames.has(p.id);
+                        return (
                             <button
                                 type="button"
-                                onClick={() =>
-                                    onUpdateSpec({ dependencies: dependencies.filter((x) => x.name !== d.name) })
-                                }
+                                key={`${p.sourceLabel}:${p.id}`}
+                                onClick={() => handleToggle(p)}
                                 className={css({
-                                    fontSize: '11px',
-                                    color: 'errorText',
-                                    bg: 'transparent',
-                                    border: 'none',
+                                    display: 'flex',
+                                    alignItems: 'flex-start',
+                                    gap: '8px',
+                                    p: '10px 12px',
+                                    bg: checked ? 'primarySubtle' : 'background',
+                                    border: '1.5px solid',
+                                    borderColor: checked ? 'primary' : 'border',
+                                    borderRadius: '10px',
+                                    textAlign: 'left',
                                     cursor: 'pointer',
+                                    _hover: { borderColor: 'borderStrong' },
                                 })}
                             >
-                                削除
+                                <span
+                                    className={css({
+                                        flexShrink: 0,
+                                        width: '16px',
+                                        height: '16px',
+                                        borderRadius: '4px',
+                                        border: '2px solid',
+                                        borderColor: checked ? 'primary' : 'border',
+                                        bg: checked ? 'primary' : 'transparent',
+                                        color: 'textOnPrimary',
+                                        display: 'flex',
+                                        alignItems: 'center',
+                                        justifyContent: 'center',
+                                        mt: '2px',
+                                    })}
+                                >
+                                    {checked && (
+                                        <svg
+                                            width="10"
+                                            height="10"
+                                            viewBox="0 0 12 12"
+                                            fill="none"
+                                            stroke="currentColor"
+                                            strokeWidth="2"
+                                        >
+                                            <path d="M2 6l3 3 5-6" />
+                                        </svg>
+                                    )}
+                                </span>
+                                <div className={css({ flex: 1, minWidth: 0 })}>
+                                    <div
+                                        className={css({
+                                            fontSize: '14px',
+                                            fontWeight: '600',
+                                            color: 'text',
+                                        })}
+                                    >
+                                        {p.name}
+                                    </div>
+                                    <div className={css({ fontSize: '11px', color: 'textSubtle', mt: '2px' })}>
+                                        v{p.version} · {p.components.length} components
+                                    </div>
+                                    <div
+                                        className={css({
+                                            fontSize: '10px',
+                                            color: 'textSubtle',
+                                            mt: '2px',
+                                            opacity: 0.8,
+                                        })}
+                                    >
+                                        {p.sourceLabel === 'local' ? 'ローカル' : p.sourceLabel}
+                                    </div>
+                                </div>
                             </button>
+                        );
+                    })}
+                    {!loading && mods.length === 0 && (
+                        <div className={css({ fontSize: '13px', color: 'textMuted', p: '12px' })}>
+                            利用可能なmodが見つかりません
                         </div>
-                    ))}
+                    )}
                 </div>
-            )}
 
-            <RegistryUrlManager registryUrls={registryUrls} onChange={setRegistryUrls} />
+                {/* 未知のmod（YAML で直接追加されたもの） */}
+                {unknownDeps.length > 0 && (
+                    <div
+                        className={css({
+                            bg: 'background',
+                            border: '1px dashed',
+                            borderColor: 'border',
+                            borderRadius: '10px',
+                            p: '10px 12px',
+                            display: 'flex',
+                            flexDirection: 'column',
+                            gap: '4px',
+                        })}
+                    >
+                        <span className={css({ fontSize: '11px', color: 'textSubtle', fontWeight: '600' })}>
+                            その他の依存（未知のmod）
+                        </span>
+                        {unknownDeps.map((d) => (
+                            <div
+                                key={d.name}
+                                className={css({
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    justifyContent: 'space-between',
+                                    fontSize: '13px',
+                                    color: 'text',
+                                })}
+                            >
+                                <span>{d.name}</span>
+                                <button
+                                    type="button"
+                                    onClick={() =>
+                                        onUpdateSpec({ dependencies: dependencies.filter((x) => x.name !== d.name) })
+                                    }
+                                    className={css({
+                                        fontSize: '11px',
+                                        color: 'errorText',
+                                        bg: 'transparent',
+                                        border: 'none',
+                                        cursor: 'pointer',
+                                    })}
+                                >
+                                    削除
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </PanelSection>
+
+            <PanelSection title="レジストリ管理" defaultOpen={false}>
+                <RegistryUrlManager registryUrls={registryUrls} onChange={setRegistryUrls} />
+            </PanelSection>
         </div>
     );
 }

--- a/packages/frontend/src/pages/world-editor/components/forms/ModSelector.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/ModSelector.tsx
@@ -1,8 +1,9 @@
 import type { WorldDefinition } from '@ubichill/shared';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { type AvailableMod, modToDependency, useAvailableMods } from '@/lib/mods/useAvailableMods';
 import { SETTINGS_KEYS, useSetting } from '@/lib/settings';
 import { css } from '@/styled-system/css';
+import { RegistryUrlManager } from './RegistryUrlManager';
 
 const isStringArray = (value: unknown): value is string[] =>
     Array.isArray(value) && value.every((v) => typeof v === 'string');
@@ -16,12 +17,10 @@ interface ModSelectorProps {
  * フォームタブ内で使う「使用するmod」セクション。
  * - ローカル + ユーザー追加レジストリから利用可能mod一覧を取得
  * - チェックボックスで dependencies に add/remove
- * - レジストリ URL を追加できる（localStorage に保存）
+ * - レジストリ URL の追加/削除/エクスポート/インポート（RegistryUrlManager）
  */
 export function ModSelector({ definition, onUpdateSpec }: ModSelectorProps) {
     const [registryUrls, setRegistryUrls] = useSetting<string[]>(SETTINGS_KEYS.editorRegistryUrls, [], isStringArray);
-    const [registryInput, setRegistryInput] = useState('');
-    const [registryError, setRegistryError] = useState('');
 
     const { mods, loading } = useAvailableMods(registryUrls);
 
@@ -37,31 +36,6 @@ export function ModSelector({ definition, onUpdateSpec }: ModSelectorProps) {
             }
         },
         [checkedNames, dependencies, onUpdateSpec],
-    );
-
-    const handleAddRegistry = useCallback(() => {
-        const trimmed = registryInput.trim();
-        if (!trimmed) return;
-        try {
-            new URL(trimmed);
-        } catch {
-            setRegistryError('URL の形式が不正です');
-            return;
-        }
-        if (registryUrls.includes(trimmed)) {
-            setRegistryError('既に追加されています');
-            return;
-        }
-        setRegistryUrls((prev) => [...prev, trimmed]);
-        setRegistryInput('');
-        setRegistryError('');
-    }, [registryInput, registryUrls, setRegistryUrls]);
-
-    const handleRemoveRegistry = useCallback(
-        (url: string) => {
-            setRegistryUrls((prev) => prev.filter((u) => u !== url));
-        },
-        [setRegistryUrls],
     );
 
     // 既に依存にあるが、利用可能リストに無い（未知のmod）も表示する
@@ -218,115 +192,7 @@ export function ModSelector({ definition, onUpdateSpec }: ModSelectorProps) {
                 </div>
             )}
 
-            {/* レジストリ URL の追加 */}
-            <div
-                className={css({
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: '6px',
-                    bg: 'background',
-                    borderRadius: '10px',
-                    p: '10px 12px',
-                    border: '1px solid',
-                    borderColor: 'border',
-                })}
-            >
-                <span className={css({ fontSize: '12px', color: 'textMuted', fontWeight: '600' })}>
-                    レジストリ URL を追加（外部mod）
-                </span>
-                <div className={css({ display: 'flex', gap: '6px' })}>
-                    <input
-                        type="url"
-                        value={registryInput}
-                        onChange={(e) => {
-                            setRegistryInput(e.target.value);
-                            setRegistryError('');
-                        }}
-                        onKeyDown={(e) => {
-                            if (e.key === 'Enter') {
-                                e.preventDefault();
-                                handleAddRegistry();
-                            }
-                        }}
-                        placeholder="https://example.com/mods/index.json"
-                        className={css({
-                            flex: 1,
-                            padding: '6px 10px',
-                            borderRadius: '8px',
-                            border: '1.5px solid',
-                            borderColor: registryError ? 'errorText' : 'border',
-                            bg: 'surface',
-                            color: 'text',
-                            fontSize: '12px',
-                            outline: 'none',
-                            _focus: { borderColor: 'primary' },
-                        })}
-                    />
-                    <button
-                        type="button"
-                        onClick={handleAddRegistry}
-                        disabled={!registryInput.trim()}
-                        className={css({
-                            padding: '6px 14px',
-                            bg: 'primary',
-                            color: 'textOnPrimary',
-                            border: 'none',
-                            borderRadius: '8px',
-                            fontSize: '12px',
-                            fontWeight: '600',
-                            cursor: 'pointer',
-                            _disabled: { opacity: 0.5, cursor: 'not-allowed' },
-                            _hover: { opacity: 0.9 },
-                        })}
-                    >
-                        追加
-                    </button>
-                </div>
-                {registryError && (
-                    <span className={css({ fontSize: '11px', color: 'errorText' })}>{registryError}</span>
-                )}
-                {registryUrls.length > 0 && (
-                    <div className={css({ display: 'flex', flexDirection: 'column', gap: '4px', mt: '2px' })}>
-                        {registryUrls.map((u) => (
-                            <div
-                                key={u}
-                                className={css({
-                                    display: 'flex',
-                                    alignItems: 'center',
-                                    justifyContent: 'space-between',
-                                    fontSize: '12px',
-                                    color: 'textMuted',
-                                    gap: '6px',
-                                })}
-                            >
-                                <span
-                                    className={css({
-                                        flex: 1,
-                                        overflow: 'hidden',
-                                        textOverflow: 'ellipsis',
-                                        whiteSpace: 'nowrap',
-                                    })}
-                                >
-                                    {u}
-                                </span>
-                                <button
-                                    type="button"
-                                    onClick={() => handleRemoveRegistry(u)}
-                                    className={css({
-                                        fontSize: '11px',
-                                        color: 'errorText',
-                                        bg: 'transparent',
-                                        border: 'none',
-                                        cursor: 'pointer',
-                                    })}
-                                >
-                                    削除
-                                </button>
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+            <RegistryUrlManager registryUrls={registryUrls} onChange={setRegistryUrls} />
         </div>
     );
 }

--- a/packages/frontend/src/pages/world-editor/components/forms/RegistryUrlManager.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/RegistryUrlManager.tsx
@@ -1,15 +1,12 @@
 /**
- * ModRegistrySection — 外部modレジストリの管理（設定タブ内）。
+ * RegistryUrlManager — 外部modレジストリ URL の追加/削除 + エクスポート/インポート。
  *
- * 追加したレジストリ URL はこの端末の localStorage にしか保存されない
- * （SETTINGS_KEYS.editorRegistryUrls、ワールドエディタと共有）。他端末・他ユーザーへ
- * 引き継ぐ手段としてエクスポート（JSONダウンロード）・インポート（JSON読込）を提供する。
+ * 追加した URL はこの端末の localStorage にしか保存されない（呼び出し側が
+ * SETTINGS_KEYS.editorRegistryUrls で管理）。他端末・他ユーザーへ引き継ぐ手段として
+ * エクスポート（JSONダウンロード）・インポート（JSON読込・マージ）を提供する。
  */
 import { useCallback, useRef, useState } from 'react';
-import { type AvailableMod, useAvailableMods } from '@/lib/mods/useAvailableMods';
-import { SETTINGS_KEYS, useSetting } from '@/lib/settings';
 import { css } from '@/styled-system/css';
-import { cardStyle, sectionHeading } from './shared';
 
 const isStringArray = (value: unknown): value is string[] =>
     Array.isArray(value) && value.every((v) => typeof v === 'string');
@@ -29,55 +26,15 @@ function downloadJson(filename: string, data: unknown): void {
     URL.revokeObjectURL(url);
 }
 
-function ModRow({ mod }: { mod: AvailableMod }) {
-    return (
-        <div
-            className={css({
-                display: 'flex',
-                alignItems: 'flex-start',
-                justifyContent: 'space-between',
-                gap: '3',
-                p: '3',
-                bg: 'surface',
-                borderRadius: '12px',
-            })}
-        >
-            <div className={css({ flex: 1, minW: 0 })}>
-                <div className={css({ fontSize: '14px', fontWeight: '600', color: 'text' })}>{mod.name}</div>
-                <div className={css({ fontSize: '11px', color: 'textSubtle', mt: '1' })}>
-                    v{mod.version} · {mod.components.length} components
-                </div>
-                {mod.components.length > 0 && (
-                    <div className={css({ fontSize: '11px', color: 'textMuted', mt: '1' })}>
-                        {mod.components.join(', ')}
-                    </div>
-                )}
-            </div>
-            <span
-                className={css({
-                    fontSize: '10px',
-                    fontWeight: '700',
-                    color: 'textSubtle',
-                    flexShrink: 0,
-                    px: '2',
-                    py: '0.5',
-                    borderRadius: '999px',
-                    bg: 'secondary',
-                })}
-            >
-                {mod.sourceLabel === 'local' ? 'ローカル' : mod.sourceLabel}
-            </span>
-        </div>
-    );
+interface RegistryUrlManagerProps {
+    registryUrls: string[];
+    onChange: (next: string[]) => void;
 }
 
-export function ModRegistrySection() {
-    const [registryUrls, setRegistryUrls] = useSetting<string[]>(SETTINGS_KEYS.editorRegistryUrls, [], isStringArray);
+export function RegistryUrlManager({ registryUrls, onChange }: RegistryUrlManagerProps) {
     const [input, setInput] = useState('');
     const [error, setError] = useState('');
     const fileInputRef = useRef<HTMLInputElement>(null);
-
-    const { mods, loading } = useAvailableMods(registryUrls);
 
     const handleAdd = useCallback(() => {
         const trimmed = input.trim();
@@ -92,16 +49,16 @@ export function ModRegistrySection() {
             setError('既に追加されています');
             return;
         }
-        setRegistryUrls((prev) => [...prev, trimmed]);
+        onChange([...registryUrls, trimmed]);
         setInput('');
         setError('');
-    }, [input, registryUrls, setRegistryUrls]);
+    }, [input, registryUrls, onChange]);
 
     const handleRemove = useCallback(
         (url: string) => {
-            setRegistryUrls((prev) => prev.filter((u) => u !== url));
+            onChange(registryUrls.filter((u) => u !== url));
         },
-        [setRegistryUrls],
+        [registryUrls, onChange],
     );
 
     const handleExport = useCallback(() => {
@@ -118,27 +75,33 @@ export function ModRegistrySection() {
                         setError('インポートファイルの形式が不正です');
                         return;
                     }
-                    setRegistryUrls((prev) => {
-                        const merged = new Set(prev);
-                        for (const url of parsed.registryUrls as string[]) merged.add(url);
-                        return [...merged];
-                    });
+                    const merged = new Set(registryUrls);
+                    for (const url of parsed.registryUrls) merged.add(url);
+                    onChange([...merged]);
                     setError('');
                 })
                 .catch(() => setError('インポートファイルの読み込みに失敗しました'));
         },
-        [setRegistryUrls],
+        [registryUrls, onChange],
     );
 
     return (
-        <div className={cardStyle}>
-            <h2 className={sectionHeading}>外部modレジストリ</h2>
-            <p className={css({ fontSize: '13px', color: 'textMuted', mb: '4', lineHeight: '1.6' })}>
-                ワールドで使える外部mod（自分で書いたmod・他の人が公開しているmod）のレジストリ URL を登録する。
-                この端末にのみ保存されるため、他端末へ移すにはエクスポート/インポートを使う。
-            </p>
-
-            <div className={css({ display: 'flex', gap: '2', mb: '2' })}>
+        <div
+            className={css({
+                display: 'flex',
+                flexDirection: 'column',
+                gap: '6px',
+                bg: 'background',
+                borderRadius: '10px',
+                p: '10px 12px',
+                border: '1px solid',
+                borderColor: 'border',
+            })}
+        >
+            <span className={css({ fontSize: '12px', color: 'textMuted', fontWeight: '600' })}>
+                レジストリ URL を追加（外部mod）
+            </span>
+            <div className={css({ display: 'flex', gap: '6px' })}>
                 <input
                     type="url"
                     value={input}
@@ -155,13 +118,13 @@ export function ModRegistrySection() {
                     placeholder="https://example.com/mods/index.json"
                     className={css({
                         flex: 1,
-                        padding: '8px 12px',
+                        padding: '6px 10px',
                         borderRadius: '8px',
                         border: '1.5px solid',
                         borderColor: error ? 'errorText' : 'border',
                         bg: 'surface',
                         color: 'text',
-                        fontSize: '13px',
+                        fontSize: '12px',
                         outline: 'none',
                         _focus: { borderColor: 'primary' },
                     })}
@@ -171,13 +134,12 @@ export function ModRegistrySection() {
                     onClick={handleAdd}
                     disabled={!input.trim()}
                     className={css({
-                        px: '4',
-                        py: '2',
-                        borderRadius: '8px',
-                        border: 'none',
+                        padding: '6px 14px',
                         bg: 'primary',
                         color: 'textOnPrimary',
-                        fontSize: '13px',
+                        border: 'none',
+                        borderRadius: '8px',
+                        fontSize: '12px',
                         fontWeight: '600',
                         cursor: 'pointer',
                         _disabled: { opacity: 0.5, cursor: 'not-allowed' },
@@ -187,10 +149,10 @@ export function ModRegistrySection() {
                     追加
                 </button>
             </div>
-            {error && <p className={css({ fontSize: '12px', color: 'errorText', mb: '2' })}>{error}</p>}
+            {error && <span className={css({ fontSize: '11px', color: 'errorText' })}>{error}</span>}
 
             {registryUrls.length > 0 && (
-                <div className={css({ display: 'flex', flexDirection: 'column', gap: '1', mb: '4' })}>
+                <div className={css({ display: 'flex', flexDirection: 'column', gap: '4px', mt: '2px' })}>
                     {registryUrls.map((url) => (
                         <div
                             key={url}
@@ -200,13 +162,12 @@ export function ModRegistrySection() {
                                 justifyContent: 'space-between',
                                 fontSize: '12px',
                                 color: 'textMuted',
-                                gap: '2',
+                                gap: '6px',
                             })}
                         >
                             <span
                                 className={css({
                                     flex: 1,
-                                    minW: 0,
                                     overflow: 'hidden',
                                     textOverflow: 'ellipsis',
                                     whiteSpace: 'nowrap',
@@ -233,20 +194,20 @@ export function ModRegistrySection() {
                 </div>
             )}
 
-            <div className={css({ display: 'flex', gap: '2', mb: '5' })}>
+            <div className={css({ display: 'flex', gap: '6px', mt: '2px' })}>
                 <button
                     type="button"
                     onClick={handleExport}
                     disabled={registryUrls.length === 0}
                     className={css({
                         px: '3',
-                        py: '1.5',
+                        py: '1',
                         borderRadius: '8px',
                         border: '1px solid',
                         borderColor: 'border',
                         bg: 'transparent',
                         color: 'text',
-                        fontSize: '12px',
+                        fontSize: '11px',
                         fontWeight: '600',
                         cursor: 'pointer',
                         _disabled: { opacity: 0.5, cursor: 'not-allowed' },
@@ -260,13 +221,13 @@ export function ModRegistrySection() {
                     onClick={() => fileInputRef.current?.click()}
                     className={css({
                         px: '3',
-                        py: '1.5',
+                        py: '1',
                         borderRadius: '8px',
                         border: '1px solid',
                         borderColor: 'border',
                         bg: 'transparent',
                         color: 'text',
-                        fontSize: '12px',
+                        fontSize: '11px',
                         fontWeight: '600',
                         cursor: 'pointer',
                         _hover: { bg: 'surfaceHover' },
@@ -285,21 +246,6 @@ export function ModRegistrySection() {
                         e.target.value = '';
                     }}
                 />
-            </div>
-
-            <h3 className={css({ fontSize: '14px', fontWeight: '700', color: 'text', mb: '2' })}>
-                利用可能なmod
-                {loading && <span className={css({ color: 'textSubtle', fontWeight: '400' })}> (読み込み中...)</span>}
-            </h3>
-            <div className={css({ display: 'flex', flexDirection: 'column', gap: '2' })}>
-                {mods.map((mod) => (
-                    <ModRow key={`${mod.sourceLabel}:${mod.id}`} mod={mod} />
-                ))}
-                {!loading && mods.length === 0 && (
-                    <div className={css({ fontSize: '13px', color: 'textMuted', p: '4', textAlign: 'center' })}>
-                        利用可能なmodが見つかりません
-                    </div>
-                )}
             </div>
         </div>
     );

--- a/packages/frontend/src/pages/world-editor/components/forms/UsedModsList.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/UsedModsList.tsx
@@ -1,0 +1,59 @@
+import type { WorldDefinition } from '@ubichill/shared';
+import { css } from '@/styled-system/css';
+
+type Dependency = NonNullable<WorldDefinition['spec']['dependencies']>[number];
+
+interface UsedModsListProps {
+    dependencies: Dependency[];
+}
+
+/**
+ * 「ワールド公開」タブで使う、使用中mod の読み取り専用一覧。
+ *
+ * ここでは追加/削除やレジストリ管理はできない（mod管理タブの責務）。
+ * definition.spec.dependencies だけから描画するため、レジストリへの fetch は発生しない
+ * — 「エディタ本体はmod管理をしない」という分離を保つため。
+ */
+export function UsedModsList({ dependencies }: UsedModsListProps) {
+    if (dependencies.length === 0) {
+        return <div className={css({ fontSize: '13px', color: 'textMuted', p: '12px' })}>使用中のmodはありません</div>;
+    }
+
+    return (
+        <div
+            className={css({
+                display: 'grid',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(220px, 1fr))',
+                gap: '8px',
+            })}
+        >
+            {dependencies.map((d) => (
+                <div
+                    key={d.name}
+                    className={css({
+                        p: '10px 12px',
+                        bg: 'background',
+                        border: '1.5px solid',
+                        borderColor: 'border',
+                        borderRadius: '10px',
+                    })}
+                >
+                    <div className={css({ fontSize: '14px', fontWeight: '600', color: 'text' })}>{d.name}</div>
+                    <div
+                        className={css({
+                            fontSize: '11px',
+                            color: 'textSubtle',
+                            mt: '2px',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        })}
+                    >
+                        {d.source.type === 'local' ? 'ローカル' : d.source.url}
+                        {d.source.version ? ` · v${d.source.version}` : ''}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/packages/frontend/src/pages/world-editor/components/forms/WorldInfoForm.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/WorldInfoForm.tsx
@@ -9,11 +9,11 @@ interface WorldInfoFormProps {
 }
 
 /**
- * ワールド情報モーダルの中身（staging）。
+ * コントロールパネル（ワールド情報 + mod管理 + 公開）の中身（staging）。
  * displayName / description / thumbnail / version / capacity / worldSize / 背景色 / 使用mod。
  *
  * フィールドの編集は draft の更新のみで、外側の definition には反映しない。
- * 「適用」ボタンが押されたタイミングで親が draft → definition へ移し替える。
+ * 「作成/保存」ボタンが押されたタイミングで親が draft → definition へ移し替えつつ保存する。
  */
 export function WorldInfoForm({ draft, onChange }: WorldInfoFormProps) {
     const definition = draft;

--- a/packages/frontend/src/pages/world-editor/components/forms/WorldPublishForm.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/WorldPublishForm.tsx
@@ -1,21 +1,24 @@
 import type { WorldDefinition } from '@ubichill/shared';
 import { css } from '@/styled-system/css';
-import { ModSelector } from './ModSelector';
+import { UsedModsList } from './UsedModsList';
 
-interface WorldInfoFormProps {
-    /** 編集中の draft definition。親 (WorldEditorPage) が状態を持ち、モーダルの footer の「適用」ボタンで反映する。 */
+interface WorldPublishFormProps {
+    /** 編集中の draft definition。親 (WorldEditorPage) が状態を持ち、コントロールパネルの「作成/保存」で反映する。 */
     draft: WorldDefinition;
     onChange: (next: WorldDefinition) => void;
 }
 
 /**
- * コントロールパネル（ワールド情報 + mod管理 + 公開）の中身（staging）。
- * displayName / description / thumbnail / version / capacity / worldSize / 背景色 / 使用mod。
+ * コントロールパネルの「ワールド公開」タブの中身（staging）。
+ * displayName / description / thumbnail / version / capacity / worldSize / 背景色。
+ *
+ * mod の追加/削除やレジストリ管理はここでは行わない（「mod管理」タブの責務）。
+ * ここでは使用中mod を読み取り専用で見せるだけ — エディタ本体はmod管理をしないという分離のため。
  *
  * フィールドの編集は draft の更新のみで、外側の definition には反映しない。
  * 「作成/保存」ボタンが押されたタイミングで親が draft → definition へ移し替えつつ保存する。
  */
-export function WorldInfoForm({ draft, onChange }: WorldInfoFormProps) {
+export function WorldPublishForm({ draft, onChange }: WorldPublishFormProps) {
     const definition = draft;
     const onUpdateSpec = (patch: Partial<WorldDefinition['spec']>) =>
         onChange({ ...draft, spec: { ...draft.spec, ...patch } });
@@ -180,7 +183,9 @@ export function WorldInfoForm({ draft, onChange }: WorldInfoFormProps) {
                 </div>
             </Field>
 
-            <ModSelector definition={definition} onUpdateSpec={onUpdateSpec} />
+            <Field label="使用中のmod">
+                <UsedModsList dependencies={spec.dependencies ?? []} />
+            </Field>
         </div>
     );
 }

--- a/packages/frontend/src/pages/world-editor/components/forms/WorldPublishForm.tsx
+++ b/packages/frontend/src/pages/world-editor/components/forms/WorldPublishForm.tsx
@@ -1,5 +1,6 @@
 import type { WorldDefinition } from '@ubichill/shared';
 import { css } from '@/styled-system/css';
+import { PanelSection } from '../PanelSection';
 import { UsedModsList } from './UsedModsList';
 
 interface WorldPublishFormProps {
@@ -31,161 +32,169 @@ export function WorldPublishForm({ draft, onChange }: WorldPublishFormProps) {
     };
 
     return (
-        <div className={css({ display: 'flex', flexDirection: 'column', gap: '4' })}>
-            <Field label="表示名（日本語可）" required>
-                <input
-                    type="text"
-                    name="world-displayName"
-                    value={spec.displayName}
-                    onChange={(e) => onUpdateSpec({ displayName: e.target.value })}
-                    maxLength={1000}
-                    placeholder="例: ぼくのワールド"
-                    className={inputStyle}
-                />
-            </Field>
-            <Field label="説明">
-                <textarea
-                    name="world-description"
-                    value={spec.description ?? ''}
-                    onChange={(e) => onUpdateSpec({ description: e.target.value || undefined })}
-                    maxLength={1000}
-                    rows={3}
-                    placeholder="このワールドについての説明"
-                    className={inputStyle}
-                />
-            </Field>
-            <Field label="サムネイル URL">
-                <input
-                    type="url"
-                    name="world-thumbnail"
-                    value={spec.thumbnail ?? ''}
-                    onChange={(e) => onUpdateSpec({ thumbnail: e.target.value || undefined })}
-                    placeholder="https://..."
-                    className={inputStyle}
-                />
-            </Field>
-            <Field label="バージョン">
-                <input
-                    type="text"
-                    name="world-version"
-                    value={definition.metadata.version}
-                    onChange={(e) => onUpdateMetadata({ version: e.target.value })}
-                    placeholder="1.0.0"
-                    className={inputStyle}
-                />
-            </Field>
-            <div className={css({ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4' })}>
-                <Field label="標準キャパシティ">
-                    <input
-                        type="number"
-                        min={1}
-                        name="world-capacity-default"
-                        value={spec.capacity.default}
-                        onChange={(e) =>
-                            onUpdateSpec({
-                                capacity: {
-                                    ...spec.capacity,
-                                    default: Number.parseInt(e.target.value, 10) || 1,
-                                },
-                            })
-                        }
-                        className={inputStyle}
-                    />
-                </Field>
-                <Field label="最大キャパシティ">
-                    <input
-                        type="number"
-                        min={1}
-                        name="world-capacity-max"
-                        value={spec.capacity.max}
-                        onChange={(e) =>
-                            onUpdateSpec({
-                                capacity: {
-                                    ...spec.capacity,
-                                    max: Number.parseInt(e.target.value, 10) || 1,
-                                },
-                            })
-                        }
-                        className={inputStyle}
-                    />
-                </Field>
-            </div>
-            <div className={css({ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4' })}>
-                <Field label="ワールド幅">
-                    <input
-                        type="number"
-                        min={100}
-                        name="world-size-width"
-                        value={env.worldSize?.width ?? 2000}
-                        onChange={(e) =>
-                            onUpdateSpec({
-                                environment: {
-                                    ...env,
-                                    worldSize: {
-                                        ...(env.worldSize ?? { width: 2000, height: 1500 }),
-                                        width: Number.parseInt(e.target.value, 10) || 100,
-                                    },
-                                },
-                            })
-                        }
-                        className={inputStyle}
-                    />
-                </Field>
-                <Field label="ワールド高さ">
-                    <input
-                        type="number"
-                        min={100}
-                        name="world-size-height"
-                        value={env.worldSize?.height ?? 1500}
-                        onChange={(e) =>
-                            onUpdateSpec({
-                                environment: {
-                                    ...env,
-                                    worldSize: {
-                                        ...(env.worldSize ?? { width: 2000, height: 1500 }),
-                                        height: Number.parseInt(e.target.value, 10) || 100,
-                                    },
-                                },
-                            })
-                        }
-                        className={inputStyle}
-                    />
-                </Field>
-            </div>
-            <Field label="背景色">
-                <div className={css({ display: 'flex', gap: '8px', alignItems: 'center' })}>
-                    <input
-                        type="color"
-                        name="world-bgColor-picker"
-                        value={env.backgroundColor ?? '#F0F8FF'}
-                        onChange={(e) =>
-                            onUpdateSpec({
-                                environment: { ...env, backgroundColor: e.target.value.toUpperCase() },
-                            })
-                        }
-                        className={css({
-                            width: '48px',
-                            height: '36px',
-                            borderRadius: '8px',
-                            border: '1px solid',
-                            borderColor: 'border',
-                            cursor: 'pointer',
-                        })}
-                    />
+        <div className={css({ display: 'flex', flexDirection: 'column', gap: '3' })}>
+            <PanelSection title="ワールド情報">
+                <Field label="表示名（日本語可）" required>
                     <input
                         type="text"
-                        name="world-bgColor"
-                        value={env.backgroundColor ?? '#F0F8FF'}
-                        onChange={(e) => onUpdateSpec({ environment: { ...env, backgroundColor: e.target.value } })}
-                        pattern="^#[0-9A-Fa-f]{6}$"
+                        name="world-displayName"
+                        value={spec.displayName}
+                        onChange={(e) => onUpdateSpec({ displayName: e.target.value })}
+                        maxLength={1000}
+                        placeholder="例: ぼくのワールド"
                         className={inputStyle}
                     />
-                </div>
-            </Field>
+                </Field>
+                <Field label="説明">
+                    <textarea
+                        name="world-description"
+                        value={spec.description ?? ''}
+                        onChange={(e) => onUpdateSpec({ description: e.target.value || undefined })}
+                        maxLength={1000}
+                        rows={3}
+                        placeholder="このワールドについての説明"
+                        className={inputStyle}
+                    />
+                </Field>
+                <Field label="バージョン">
+                    <input
+                        type="text"
+                        name="world-version"
+                        value={definition.metadata.version}
+                        onChange={(e) => onUpdateMetadata({ version: e.target.value })}
+                        placeholder="1.0.0"
+                        className={inputStyle}
+                    />
+                </Field>
+            </PanelSection>
 
-            <Field label="使用中のmod">
+            <PanelSection title="サムネイル">
+                <Field label="サムネイル URL">
+                    <input
+                        type="url"
+                        name="world-thumbnail"
+                        value={spec.thumbnail ?? ''}
+                        onChange={(e) => onUpdateSpec({ thumbnail: e.target.value || undefined })}
+                        placeholder="https://..."
+                        className={inputStyle}
+                    />
+                </Field>
+            </PanelSection>
+
+            <PanelSection title="ワールド設定">
+                <div className={css({ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4' })}>
+                    <Field label="標準キャパシティ">
+                        <input
+                            type="number"
+                            min={1}
+                            name="world-capacity-default"
+                            value={spec.capacity.default}
+                            onChange={(e) =>
+                                onUpdateSpec({
+                                    capacity: {
+                                        ...spec.capacity,
+                                        default: Number.parseInt(e.target.value, 10) || 1,
+                                    },
+                                })
+                            }
+                            className={inputStyle}
+                        />
+                    </Field>
+                    <Field label="最大キャパシティ">
+                        <input
+                            type="number"
+                            min={1}
+                            name="world-capacity-max"
+                            value={spec.capacity.max}
+                            onChange={(e) =>
+                                onUpdateSpec({
+                                    capacity: {
+                                        ...spec.capacity,
+                                        max: Number.parseInt(e.target.value, 10) || 1,
+                                    },
+                                })
+                            }
+                            className={inputStyle}
+                        />
+                    </Field>
+                </div>
+                <div className={css({ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '4' })}>
+                    <Field label="ワールド幅">
+                        <input
+                            type="number"
+                            min={100}
+                            name="world-size-width"
+                            value={env.worldSize?.width ?? 2000}
+                            onChange={(e) =>
+                                onUpdateSpec({
+                                    environment: {
+                                        ...env,
+                                        worldSize: {
+                                            ...(env.worldSize ?? { width: 2000, height: 1500 }),
+                                            width: Number.parseInt(e.target.value, 10) || 100,
+                                        },
+                                    },
+                                })
+                            }
+                            className={inputStyle}
+                        />
+                    </Field>
+                    <Field label="ワールド高さ">
+                        <input
+                            type="number"
+                            min={100}
+                            name="world-size-height"
+                            value={env.worldSize?.height ?? 1500}
+                            onChange={(e) =>
+                                onUpdateSpec({
+                                    environment: {
+                                        ...env,
+                                        worldSize: {
+                                            ...(env.worldSize ?? { width: 2000, height: 1500 }),
+                                            height: Number.parseInt(e.target.value, 10) || 100,
+                                        },
+                                    },
+                                })
+                            }
+                            className={inputStyle}
+                        />
+                    </Field>
+                </div>
+                <Field label="背景色">
+                    <div className={css({ display: 'flex', gap: '8px', alignItems: 'center' })}>
+                        <input
+                            type="color"
+                            name="world-bgColor-picker"
+                            value={env.backgroundColor ?? '#F0F8FF'}
+                            onChange={(e) =>
+                                onUpdateSpec({
+                                    environment: { ...env, backgroundColor: e.target.value.toUpperCase() },
+                                })
+                            }
+                            className={css({
+                                width: '48px',
+                                height: '36px',
+                                borderRadius: '8px',
+                                border: '1px solid',
+                                borderColor: 'border',
+                                cursor: 'pointer',
+                            })}
+                        />
+                        <input
+                            type="text"
+                            name="world-bgColor"
+                            value={env.backgroundColor ?? '#F0F8FF'}
+                            onChange={(e) => onUpdateSpec({ environment: { ...env, backgroundColor: e.target.value } })}
+                            pattern="^#[0-9A-Fa-f]{6}$"
+                            className={inputStyle}
+                        />
+                    </div>
+                </Field>
+            </PanelSection>
+
+            <PanelSection title="使用中のmod" defaultOpen={false}>
                 <UsedModsList dependencies={spec.dependencies ?? []} />
-            </Field>
+            </PanelSection>
         </div>
     );
 }

--- a/packages/frontend/src/pages/world-editor/hooks/useAvailableEntityKinds.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useAvailableEntityKinds.ts
@@ -81,22 +81,29 @@ const MOD_BASE_URL: string = (() => {
 const indexCache = new Map<string, Promise<ModIndex | null>>();
 const manifestCache = new Map<string, Promise<VersionedManifest | null>>();
 
-function fetchIndex(name: string): Promise<ModIndex | null> {
-    let p = indexCache.get(name);
+/** `source.type === 'url'` の mod は自身の `source.url` を base にする（グローバル `MOD_BASE_URL` はローカルmod専用）。 */
+function resolveBase(dep: NonNullable<WorldDefinition['spec']['dependencies']>[number]): string {
+    if (dep.source.type === 'url' && dep.source.url) return dep.source.url.replace(/\/$/, '');
+    return MOD_BASE_URL;
+}
+
+function fetchIndex(base: string, name: string): Promise<ModIndex | null> {
+    const key = `${base}/${name}`;
+    let p = indexCache.get(key);
     if (!p) {
-        p = fetch(`${MOD_BASE_URL}/${name}/mod.json`, { cache: 'no-store' })
+        p = fetch(`${base}/${name}/mod.json`, { cache: 'no-store' })
             .then((r) => (r.ok ? (r.json() as Promise<ModIndex>) : null))
             .catch(() => null);
-        indexCache.set(name, p);
+        indexCache.set(key, p);
     }
     return p;
 }
 
-function fetchManifest(name: string, version: string): Promise<VersionedManifest | null> {
-    const key = `${name}@${version}`;
+function fetchManifest(base: string, name: string, version: string): Promise<VersionedManifest | null> {
+    const key = `${base}/${name}@${version}`;
     let p = manifestCache.get(key);
     if (!p) {
-        p = fetch(`${MOD_BASE_URL}/${name}/v${version}/manifest.json`)
+        p = fetch(`${base}/${name}/v${version}/manifest.json`)
             .then((r) => (r.ok ? (r.json() as Promise<VersionedManifest>) : null))
             .catch(() => null);
         manifestCache.set(key, p);
@@ -131,11 +138,12 @@ export function useAvailableEntityKinds(definition: WorldDefinition | null): {
         setLoading(true);
         Promise.all(
             deps.map(async (dep) => {
-                const idx = await fetchIndex(dep.name);
+                const base = resolveBase(dep);
+                const idx = await fetchIndex(base, dep.name);
                 if (!idx?.version) return [];
-                const manifest = await fetchManifest(dep.name, idx.version);
+                const manifest = await fetchManifest(base, dep.name, idx.version);
                 const components = manifest?.components ?? {};
-                const versionedBase = `${MOD_BASE_URL}/${dep.name}/v${idx.version}`;
+                const versionedBase = `${base}/${dep.name}/v${idx.version}`;
                 return Object.entries(components).map(([kind, meta]) => ({
                     modName: dep.name,
                     kind,

--- a/packages/frontend/src/pages/world-editor/hooks/useEditorModals.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useEditorModals.ts
@@ -2,7 +2,7 @@ import { type WorldDefinition, WorldDefinitionSchema } from '@ubichill/shared';
 import { useCallback, useState } from 'react';
 import yaml from 'yaml';
 
-export type EditorModal = 'info' | 'yaml' | null;
+export type ControlPanelTab = 'publish' | 'mods' | 'yaml';
 
 interface UseEditorModalsArgs {
     definition: WorldDefinition;
@@ -10,104 +10,99 @@ interface UseEditorModalsArgs {
 }
 
 /**
- * ワールド情報モーダルと YAML モーダルの開閉・staging draft を集約する hook。
+ * コントロールパネル（ワールド公開 / mod管理 / YAML の3タブ）の開閉・staging draft を集約する hook。
  *
  * 設計:
- * - 各モーダルは「draft」を内部で保持し、ユーザーが「適用」したときにだけ
- *   `onCommit(definition)` を通じて外側の definition を更新する。
+ * - 3タブは単一の `draft`（WorldDefinition）を共有する。「作成/保存」ボタンでのみ
+ *   `onCommit(draft)` を通じて外側の definition を更新する。
+ * - YAML タブはテキスト編集用の別バッファ（yamlText）を持つが、有効な YAML であれば
+ *   即座に draft へ反映する（タブを切り替えても他タブに反映されるように）。
  * - 「キャンセル」または背景クリックで draft は破棄。
  */
 export function useEditorModals({ definition, onCommit }: UseEditorModalsArgs) {
-    const [openModal, setOpenModal] = useState<EditorModal>(null);
+    const [open, setOpen] = useState(false);
+    const [activeTab, setActiveTab] = useState<ControlPanelTab>('publish');
+    const [draft, setDraft] = useState<WorldDefinition | null>(null);
+    const [yamlText, setYamlText] = useState('');
+    const [yamlError, setYamlError] = useState('');
 
-    // ---------- info モーダル ----------
-    const [infoDraft, setInfoDraft] = useState<WorldDefinition | null>(null);
+    const openControlPanel = useCallback(
+        (tab: ControlPanelTab = 'publish') => {
+            setDraft(definition);
+            setYamlText(yaml.stringify(definition));
+            setYamlError('');
+            setActiveTab(tab);
+            setOpen(true);
+        },
+        [definition],
+    );
 
-    const openInfo = useCallback(() => {
-        setInfoDraft(definition);
-        setOpenModal('info');
-    }, [definition]);
-    const applyInfo = useCallback(() => {
-        if (infoDraft) onCommit(infoDraft);
-        setInfoDraft(null);
-        setOpenModal(null);
-    }, [infoDraft, onCommit]);
-    const cancelInfo = useCallback(() => {
-        setInfoDraft(null);
-        setOpenModal(null);
+    const closeControlPanel = useCallback(() => {
+        setDraft(null);
+        setOpen(false);
     }, []);
 
-    // ---------- yaml モーダル ----------
-    const [yamlDraft, setYamlDraft] = useState<string>('');
-    const [yamlDraftError, setYamlDraftError] = useState<string>('');
+    // タブ切り替え時: YAML タブに入る際は draft の最新状態からテキストを作り直す
+    // （他タブでのフィールド編集を YAML 表示に反映するため。逆方向は changeYamlText 側で処理）。
+    const switchTab = useCallback(
+        (tab: ControlPanelTab) => {
+            if (tab === 'yaml' && draft) {
+                setYamlText(yaml.stringify(draft));
+                setYamlError('');
+            }
+            setActiveTab(tab);
+        },
+        [draft],
+    );
 
-    const openYaml = useCallback(() => {
-        setYamlDraft(yaml.stringify(definition));
-        setYamlDraftError('');
-        setOpenModal('yaml');
-    }, [definition]);
-
-    const changeYamlDraft = useCallback((text: string) => {
-        setYamlDraft(text);
+    const changeYamlText = useCallback((text: string) => {
+        setYamlText(text);
         try {
             const parsed = yaml.parse(text) as unknown;
             const result = WorldDefinitionSchema.safeParse(parsed);
-            setYamlDraftError(result.success ? '' : (result.error.issues[0]?.message ?? 'スキーマ違反'));
-        } catch (e) {
-            setYamlDraftError(e instanceof Error ? e.message : 'YAML parse error');
-        }
-    }, []);
-
-    const applyYaml = useCallback(() => {
-        try {
-            const parsed = yaml.parse(yamlDraft) as unknown;
-            const result = WorldDefinitionSchema.safeParse(parsed);
-            if (!result.success) {
-                setYamlDraftError(result.error.issues[0]?.message ?? 'スキーマ違反');
-                return;
+            if (result.success) {
+                setDraft(result.data);
+                setYamlError('');
+            } else {
+                setYamlError(result.error.issues[0]?.message ?? 'スキーマ違反');
             }
-            onCommit(result.data);
-            setOpenModal(null);
-            setYamlDraftError('');
         } catch (e) {
-            setYamlDraftError(e instanceof Error ? e.message : 'YAML parse error');
-        }
-    }, [yamlDraft, onCommit]);
-
-    const cancelYaml = useCallback(() => {
-        setYamlDraftError('');
-        setOpenModal(null);
-    }, []);
-
-    // ---------- ファイルアップロード（YAML draft に書き込み） ----------
-    const uploadYamlFile = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-        try {
-            const text = await file.text();
-            setYamlDraft(text);
-            setOpenModal('yaml');
-            setYamlDraftError('');
-        } finally {
-            e.target.value = '';
+            setYamlError(e instanceof Error ? e.message : 'YAML parse error');
         }
     }, []);
+
+    const uploadYamlFile = useCallback(
+        async (e: React.ChangeEvent<HTMLInputElement>) => {
+            const file = e.target.files?.[0];
+            if (!file) return;
+            try {
+                const text = await file.text();
+                changeYamlText(text);
+                setActiveTab('yaml');
+            } finally {
+                e.target.value = '';
+            }
+        },
+        [changeYamlText],
+    );
+
+    const applyControlPanel = useCallback(() => {
+        if (draft) onCommit(draft);
+        closeControlPanel();
+    }, [draft, onCommit, closeControlPanel]);
 
     return {
-        openModal,
-        // info
-        infoDraft,
-        setInfoDraft,
-        openInfo,
-        applyInfo,
-        cancelInfo,
-        // yaml
-        yamlDraft,
-        yamlDraftError,
-        openYaml,
-        changeYamlDraft,
-        applyYaml,
-        cancelYaml,
+        open,
+        activeTab,
+        switchTab,
+        draft,
+        setDraft,
+        openControlPanel,
+        closeControlPanel,
+        applyControlPanel,
+        yamlText,
+        yamlError,
+        changeYamlText,
         uploadYamlFile,
     };
 }

--- a/packages/frontend/src/pages/world-editor/hooks/useModAssets.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useModAssets.ts
@@ -1,8 +1,11 @@
+import type { WorldDefinition } from '@ubichill/shared';
 import { useEffect, useState } from 'react';
 
 export type AssetNode =
     | { kind: 'folder'; name: string; children: AssetNode[] }
     | { kind: 'file'; name: string; path: string; url: string };
+
+type Dependency = NonNullable<WorldDefinition['spec']['dependencies']>[number];
 
 interface ModIndex {
     id: string;
@@ -24,24 +27,31 @@ const MOD_BASE_URL: string = (() => {
 const indexCache = new Map<string, Promise<ModIndex | null>>();
 const manifestCache = new Map<string, Promise<VersionedManifest | null>>();
 
-function fetchIndex(name: string): Promise<ModIndex | null> {
-    let p = indexCache.get(name);
+/** `source.type === 'url'` の mod は自身の `source.url` を base にする（グローバル `MOD_BASE_URL` はローカルmod専用）。 */
+function resolveBase(dep: Dependency): string {
+    if (dep.source.type === 'url' && dep.source.url) return dep.source.url.replace(/\/$/, '');
+    return MOD_BASE_URL;
+}
+
+function fetchIndex(base: string, name: string): Promise<ModIndex | null> {
+    const key = `${base}/${name}`;
+    let p = indexCache.get(key);
     if (!p) {
-        p = fetch(`${MOD_BASE_URL}/${name}/mod.json`, { cache: 'no-store' })
+        p = fetch(`${base}/${name}/mod.json`, { cache: 'no-store' })
             .then((r) => (r.ok ? (r.json() as Promise<ModIndex>) : null))
             .catch(() => null);
-        indexCache.set(name, p);
+        indexCache.set(key, p);
     }
     return p;
 }
 
-function fetchManifest(name: string, version: string): Promise<VersionedManifest | null> {
-    const key = `${name}@${version}`;
+function fetchManifest(base: string, name: string, version: string): Promise<VersionedManifest | null> {
+    const key = `${base}/${name}@${version}`;
     let p = manifestCache.get(key);
     if (!p) {
         // cache: 'no-store' — manifest はビルド毎に workerUrl のハッシュや
         // assets リストが変わるため、ブラウザキャッシュを必ず迂回する。
-        p = fetch(`${MOD_BASE_URL}/${name}/v${version}/manifest.json`, { cache: 'no-store' })
+        p = fetch(`${base}/${name}/v${version}/manifest.json`, { cache: 'no-store' })
             .then((r) => (r.ok ? (r.json() as Promise<VersionedManifest>) : null))
             .catch(() => null);
         manifestCache.set(key, p);
@@ -86,30 +96,34 @@ function buildAssetTree(paths: string[], base: string): AssetNode[] {
 }
 
 /** mod manifest の `assets` をフォルダツリーとして取得する。 */
-export function useModAssets(modNames: string[]): {
+export function useModAssets(dependencies: Dependency[]): {
     treesByMod: Map<string, AssetNode[]>;
     loading: boolean;
 } {
     const [treesByMod, setTreesByMod] = useState<Map<string, AssetNode[]>>(new Map());
     const [loading, setLoading] = useState(false);
 
-    const key = [...modNames].sort().join(',');
+    const key = dependencies
+        .map((d) => d.name)
+        .sort()
+        .join(',');
 
     // biome-ignore lint/correctness/useExhaustiveDependencies: key で deps を安定化
     useEffect(() => {
-        if (modNames.length === 0) {
+        if (dependencies.length === 0) {
             setTreesByMod(new Map());
             return;
         }
         let cancelled = false;
         setLoading(true);
         Promise.all(
-            modNames.map(async (name): Promise<[string, AssetNode[]]> => {
-                const idx = await fetchIndex(name);
-                if (!idx?.version) return [name, []];
-                const manifest = await fetchManifest(name, idx.version);
-                const base = `${MOD_BASE_URL}/${name}/v${idx.version}`;
-                return [name, buildAssetTree(manifest?.assets ?? [], base)];
+            dependencies.map(async (dep): Promise<[string, AssetNode[]]> => {
+                const base0 = resolveBase(dep);
+                const idx = await fetchIndex(base0, dep.name);
+                if (!idx?.version) return [dep.name, []];
+                const manifest = await fetchManifest(base0, dep.name, idx.version);
+                const base = `${base0}/${dep.name}/v${idx.version}`;
+                return [dep.name, buildAssetTree(manifest?.assets ?? [], base)];
             }),
         )
             .then((results) => {

--- a/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
+++ b/packages/frontend/src/pages/world-editor/hooks/useWorldEditorApi.ts
@@ -24,43 +24,50 @@ export function useWorldEditorApi({ isEdit, worldId, definition, onSavedYamlChan
     const navigate = useNavigate();
     const [saving, setSaving] = useState(false);
 
-    const save = useCallback(async () => {
-        setSaving(true);
-        onError('');
-        try {
-            // 保存時に mod 完全性ロックを計算する。lock は人間が書く YAML には埋めず、
-            // body の別フィールドで送ってサーバ側の別カラムに保存する（YAML はクリーンに保つ）。
-            // 外部公開時、そのワールドを読む側は兄弟エンドポイントの lock と hash 照合して
-            // 差し替え mod の実行を拒否できる（配布者を信頼しない）。
-            const lock = await buildWorldLock(definition);
-            const text = yaml.stringify(definition);
-            const url =
-                isEdit && worldId ? `${API_BASE}/api/v1/worlds/${worldId}/yaml` : `${API_BASE}/api/v1/worlds/yaml`;
-            const method = isEdit ? 'PUT' : 'POST';
-            const res = await fetch(url, {
-                method,
-                headers: { 'Content-Type': 'application/json' },
-                credentials: 'include',
-                body: JSON.stringify({ yaml: text, lock }),
-            });
-            if (!res.ok) {
-                const data = (await res.json().catch(() => ({}))) as { error?: string };
-                throw new Error(data.error ?? `HTTP ${res.status}`);
+    // overrideDefinition: コントロールパネルで draft を適用した直後は setDefinition の反映が
+    // 次の render まで届かないため、保存対象を明示的に渡せるようにする（React state の
+    // 非同期更新タイミングに依存しないため）。
+    const save = useCallback(
+        async (overrideDefinition?: WorldDefinition) => {
+            const target = overrideDefinition ?? definition;
+            setSaving(true);
+            onError('');
+            try {
+                // 保存時に mod 完全性ロックを計算する。lock は人間が書く YAML には埋めず、
+                // body の別フィールドで送ってサーバ側の別カラムに保存する（YAML はクリーンに保つ）。
+                // 外部公開時、そのワールドを読む側は兄弟エンドポイントの lock と hash 照合して
+                // 差し替え mod の実行を拒否できる（配布者を信頼しない）。
+                const lock = await buildWorldLock(target);
+                const text = yaml.stringify(target);
+                const url =
+                    isEdit && worldId ? `${API_BASE}/api/v1/worlds/${worldId}/yaml` : `${API_BASE}/api/v1/worlds/yaml`;
+                const method = isEdit ? 'PUT' : 'POST';
+                const res = await fetch(url, {
+                    method,
+                    headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
+                    body: JSON.stringify({ yaml: text, lock }),
+                });
+                if (!res.ok) {
+                    const data = (await res.json().catch(() => ({}))) as { error?: string };
+                    throw new Error(data.error ?? `HTTP ${res.status}`);
+                }
+                // 新規作成: サーバー生成の worldId で編集画面に遷移して以降は dirty 解消できる状態に
+                if (!isEdit) {
+                    const created = (await res.json()) as { id: string };
+                    navigate(`/world/${created.id}/edit`, { replace: true });
+                    return;
+                }
+                // 編集モード: dirty=false にするため savedYaml を更新
+                onSavedYamlChange(text);
+            } catch (e) {
+                onError(e instanceof Error ? e.message : '保存失敗');
+            } finally {
+                setSaving(false);
             }
-            // 新規作成: サーバー生成の worldId で編集画面に遷移して以降は dirty 解消できる状態に
-            if (!isEdit) {
-                const created = (await res.json()) as { id: string };
-                navigate(`/world/${created.id}/edit`, { replace: true });
-                return;
-            }
-            // 編集モード: dirty=false にするため savedYaml を更新
-            onSavedYamlChange(text);
-        } catch (e) {
-            onError(e instanceof Error ? e.message : '保存失敗');
-        } finally {
-            setSaving(false);
-        }
-    }, [definition, isEdit, worldId, navigate, onSavedYamlChange, onError]);
+        },
+        [definition, isEdit, worldId, navigate, onSavedYamlChange, onError],
+    );
 
     const remove = useCallback(async () => {
         if (!worldId) return;


### PR DESCRIPTION
## 概要
外部modレジストリ管理をSettingsタブから削除しWorld Editorに統合。「ワールド情報」モーダルを「コントロールパネル」として拡張し、「ワールド公開」「mod管理」「YAML」の3タブに分割。各タブの中身をVRChat SDK Builder風の折りたたみセクションで整理。さらに外部URL modのアセット一覧が空になる不具合を修正し、削除ボタンをコントロールパネルのDanger Zoneへ移動した。

**マージは急ぎません。レビューをお願いします。**

## 背景・経緯（5段階）
1. 「mod管理画面はワールド作成時にも見たい。そこでしかほぼ使わないと思う」 → Settingsタブのmod管理UIを削除し、World Editorに統合（4fe4820）。
2. 「別のモーダルで大きめに見たい」「作成ボタンなど全てワールド情報に集約したほうがいい」「コントロールパネルにしてほしい」 → モーダルを拡張し「コントロールパネル」として、作成/保存ボタンもここに統合（bb96f51）。
3. 「mod管理は別タブにしてワールド公開タブではmodは操作できなくて使用されてるmodとして見れる感じで管理は別にしたい。エディタはプラグイン管理をやらないはず」 → コントロールパネルを3タブに分割（a551bbd）。
4. VRChat SDK Builderパネルの画像を提示され「こんな感じでモーダルのサイズは変えないで」 → タブ構成は維持したまま、各タブの中身を折りたたみセクションで整理（73f12e3）。
5. 「assetで外部で入れたvideoplayerの中が空になってしまってる。削除ボタンはコントロールパネルの中の1番したのDangerZoneで」 → 外部URL modのアセット一覧が空になる不具合を修正し、削除ボタンをDanger Zoneへ移動（b209947）。

mod依存関係は独自DBを作らず、既存どおりワールドのYAML定義（`spec.dependencies`）に保持したまま。追加のDBスキーマ変更は無し。

## 変更内容（最終形）
コントロールパネルは3タブ構成:
- **ワールド公開**: 折りたたみセクション「ワールド情報」「サムネイル」「ワールド設定」「使用中のmod」（読み取り専用一覧） + 最下部に **Danger Zone**（既定で折りたたみ、ワールド削除）
- **mod管理**: 折りたたみセクション「使用するmod」（チェックボックス追加/削除）「レジストリ管理」
- **YAML**: draftと双方向反映するYAML編集タブ

ヘッダーの独立した「作成」/「保存」/「YAML」/「削除」ボタンはすべて廃止し、「コントロールパネル」ボタン1つに統合。

### バグ修正: 外部URL modのアセット一覧が空になる不具合
`useAvailableEntityKinds` / `useModAssets` が `dependencies[].source.url` を無視し、常にグローバル `MOD_BASE_URL`（ローカルmod用の `/mods`）から `mod.json`/`manifest.json` を fetch していたため、外部URL mod（video-player等）は404 → kinds/assetsが空配列になり、アセットパネルの中身が空表示になっていた。

各modの`dependency`から `source.type==='url' ? source.url : MOD_BASE_URL` をper-mod baseとして解決するように修正（`packages/loader/src/genLock.ts` がCLI側で行っているper-dep URL分岐と同じパターン）。同じ根本原因のクラスとして、ブラウザ保存時のmodロック生成（`buildWorldLock.ts`）にも同じper-dep URL overrideロジックを適用した。

### 見送った項目（別対応）
VRChat SDK画像を見て「サムネイルをD&Dまたはワールドスクリーンショットで設定したい」「後でパフォーマンスを明確に測定できるようにしたい」という要望も出たが、画像アップロードAPI・DOMキャプチャ手段が現状無く新規のバックエンド/依存追加が必要な規模のため、今回のPRの範囲外として見送った。

## テスト
- `pnpm lint` / `pnpm typecheck` / `npx vitest run` すべてクリーン
- Playwrightで実ブラウザ確認済み:
  - Settingsタブにmodレジストリ関連UIが表示されないこと
  - ヘッダーが「スナップ」「コントロールパネル」のみになっていること（削除ボタンも含めすべて消えていること）
  - アセットパネルで外部URL mod（video-player）のComponents（controls/playlist/screen/search）が正しく表示されること
  - コントロールパネル最下部のDanger Zoneから実際にワールドを削除できること
  - 各タブ・各セクションの開閉・編集・保存フローが正常に動作すること
  - コンソールエラー/警告が出ないこと（テストワールドは確認後に削除済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)