### PR TITLE
fix: video-playerのMEDIA_ELEMENT_ERROR原因調査＋Ubi.ui.renderの自動再描画

### DIFF
--- a/.changeset/reactive-ui-render.md
+++ b/.changeset/reactive-ui-render.md
@@ -1,0 +1,5 @@
+---
+"ubichill": minor
+---
+
+`Ubi.ui.render(factory, targetId)` が `factory()` 実行中に読んだ `Ubi.state` のキーを自動追跡し、そのキーが変わったときだけ自動で再描画するようになりました。`state.onChange(key, render)` による手動の再描画結線は不要になります（既存の呼び出しを残しても害はありません）。読まなかったキーの変化では再描画されないため、postMessage の送信数は増えません。

--- a/.changeset/reactive-ui-render.md
+++ b/.changeset/reactive-ui-render.md
@@ -3,3 +3,5 @@
 ---
 
 `Ubi.ui.render(factory, targetId)` が `factory()` 実行中に読んだ `Ubi.state` のキーを自動追跡し、そのキーが変わったときだけ自動で再描画するようになりました。`state.onChange(key, render)` による手動の再描画結線は不要になります（既存の呼び出しを残しても害はありません）。読まなかったキーの変化では再描画されないため、postMessage の送信数は増えません。
+
+さらに、Worker ファイルが `export default function() { return <jsx/> }` のように UI をデフォルトエクスポートすると、初回の `Ubi.ui.render()` 呼び出しも不要になり自動でマウントされます。`Ubi.grip` の `isMine`/`holder` 等は内部で `Ubi.state` を読むため、これらも自動追跡の対象です。

--- a/mods/pen/src/pen.worker.tsx
+++ b/mods/pen/src/pen.worker.tsx
@@ -82,10 +82,11 @@ const PenSvg = ({ color }: { color: string }) => (
 );
 
 function renderPen(): void {
-    const color = pen.local.color;
+    // factory() 内で読んだ pen.local.* キーは自動で依存追跡される。
+    // strokeWidth はここでは読んでいないので、変わっても再描画されない。
     Ubi.ui.render(
         () => (
-            <Gripable grip={grip} style={{ color, width: '36px', height: '48px' }}>
+            <Gripable grip={grip} style={{ color: pen.local.color, width: '36px', height: '48px' }}>
                 <div
                     style={{
                         width: '100%',
@@ -98,7 +99,7 @@ function renderPen(): void {
                         transition: 'transform 0.15s ease',
                     }}
                 >
-                    <PenSvg color={color} />
+                    <PenSvg color={pen.local.color} />
                 </div>
             </Gripable>
         ),
@@ -106,10 +107,8 @@ function renderPen(): void {
     );
 }
 
-// 状態変化はすべて onChange で宣言的に再描画
-pen.onChange('color', renderPen);
-pen.onChange('strokeWidth', renderPen);
+// grip.isMine は Ubi.state ではないので自動追跡の対象外。明示的に結線する。
 grip.onChange(renderPen);
 
-// 初期 1 回レンダー
+// 初期 1 回レンダー。以降 color の変化は自動で再描画される（onChange の手動結線は不要）。
 renderPen();

--- a/mods/pen/src/pen.worker.tsx
+++ b/mods/pen/src/pen.worker.tsx
@@ -81,34 +81,28 @@ const PenSvg = ({ color }: { color: string }) => (
     </svg>
 );
 
-function renderPen(): void {
-    // factory() 内で読んだ pen.local.* キーは自動で依存追跡される。
-    // strokeWidth はここでは読んでいないので、変わっても再描画されない。
-    Ubi.ui.render(
-        () => (
-            <Gripable grip={grip} style={{ color: pen.local.color, width: '36px', height: '48px' }}>
-                <div
-                    style={{
-                        width: '100%',
-                        height: '100%',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        transform: grip.isMine ? 'rotate(-30deg)' : 'none',
-                        transformOrigin: 'bottom right',
-                        transition: 'transform 0.15s ease',
-                    }}
-                >
-                    <PenSvg color={pen.local.color} />
-                </div>
-            </Gripable>
-        ),
-        'pen-button',
+// export default = このComponentの唯一のUI。ビルド時にバンドルされ、Sandbox が起動時に
+// 一度だけ自動で Ubi.ui.render(default) する（手動の初期呼び出しは不要）。
+// ここで読む pen.local.color / grip.isMine（内部的に Ubi.state 経由）は自動で依存追跡され、
+// 変化時だけ自動的に再実行される。onChange の手動結線は不要（strokeWidth はここで読んで
+// いないので、変わっても再描画されない）。
+export default function PenView() {
+    return (
+        <Gripable grip={grip} style={{ color: pen.local.color, width: '36px', height: '48px' }}>
+            <div
+                style={{
+                    width: '100%',
+                    height: '100%',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    transform: grip.isMine ? 'rotate(-30deg)' : 'none',
+                    transformOrigin: 'bottom right',
+                    transition: 'transform 0.15s ease',
+                }}
+            >
+                <PenSvg color={pen.local.color} />
+            </div>
+        </Gripable>
     );
 }
-
-// grip.isMine は Ubi.state ではないので自動追跡の対象外。明示的に結線する。
-grip.onChange(renderPen);
-
-// 初期 1 回レンダー。以降 color の変化は自動で再描画される（onChange の手動結線は不要）。
-renderPen();

--- a/mods/pen/src/tray.worker.tsx
+++ b/mods/pen/src/tray.worker.tsx
@@ -18,8 +18,8 @@ export const config: ComponentConfig = {
 
 const THICKNESS_OPTIONS = [2, 4, 8, 12];
 
-Ubi.ui.render(
-    () => (
+export default function TrayView() {
+    return (
         <div style={{ position: 'absolute', inset: '0', pointerEvents: 'none' }}>
             <button
                 type="button"
@@ -97,6 +97,5 @@ Ubi.ui.render(
                 ))}
             </div>
         </div>
-    ),
-    'pen-tray',
-);
+    );
+}

--- a/packages/sandbox/src/worker/sandbox.worker.ts
+++ b/packages/sandbox/src/worker/sandbox.worker.ts
@@ -3,6 +3,7 @@ import {
     CommandType,
     checkProtocolCompatibility,
     HostEventType,
+    MOD_EXPORTS_GLOBAL_NAME,
     type ModGuestCommand,
     type ModHostEvent,
     PROTOCOL_VERSION,
@@ -122,6 +123,9 @@ self.addEventListener('message', (e: MessageEvent<ModHostEvent>) => {
             `"use strict";
             try {
                 ${event.payload.code}
+                if (typeof ${MOD_EXPORTS_GLOBAL_NAME} !== "undefined" && ${MOD_EXPORTS_GLOBAL_NAME} && typeof ${MOD_EXPORTS_GLOBAL_NAME}.default === "function") {
+                    Ubi.ui.render(${MOD_EXPORTS_GLOBAL_NAME}.default, "default");
+                }
             } catch (err) {
                 console.error("[Sandbox:${modId}] mod実行エラー", err);
                 throw err;

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -27,11 +27,12 @@ const counter = Ubi.state.define({
     count: Ubi.state.sync(0), // 共有 + 永続。ホスト再起動後も保持される
 });
 
-function render(): void {
-    Ubi.ui.render(() => <button onClick={() => counter.local.count++}>count: {counter.local.count}</button>, 'counter-root');
+// export default = このWorkerのUI。ビルド時にバンドルされ、初回のみ自動で描画される。
+// この中で読んだ Ubi.state のキー（ここでは count）は自動で依存追跡され、
+// 変化時だけ自動的に再実行される（onChange での手動結線・初期呼び出しは不要）。
+export default function Counter() {
+    return <button onClick={() => counter.local.count++}>count: {counter.local.count}</button>;
 }
-counter.onChange('count', render);
-render();
 ```
 
 主要なネームスペース（詳細は `Ubi` 型の docstring を参照）:

--- a/packages/sdk/cli/build.ts
+++ b/packages/sdk/cli/build.ts
@@ -2,7 +2,7 @@
  * CLI ビルドツールのコア — mod.json を廃止し、package.json + Worker コード内の
  * `export const config` を元にマニフェスト・lock.json を自動生成する。
  */
-import { detectCapabilities } from '@ubichill/shared';
+import { detectCapabilities, MOD_EXPORTS_GLOBAL_NAME } from '@ubichill/shared';
 import * as esbuild from 'esbuild';
 import { createHash } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs';
@@ -258,6 +258,7 @@ async function bundleWorker(entryPath: string, tsconfig?: string): Promise<strin
         entryPoints: [entryPath],
         bundle: true,
         format: 'iife',
+        globalName: MOD_EXPORTS_GLOBAL_NAME,
         platform: 'browser',
         target: 'es2022',
         jsx: 'automatic',
@@ -371,12 +372,14 @@ export async function buildMod(modDir: string, options: BuildOptions = {}): Prom
         cleanOldBundles(publicComponentDir, outFilename);
         writeFileSync(join(publicComponentDir, outFilename), code, 'utf-8');
 
-        // capability をコードから自動検出。
-        const detected = detectCapabilities(code);
-
         // config からメタデータを取得
         const srcCode = readFileSync(workerPath, 'utf-8');
         const config = extractConfigFromCode(srcCode);
+
+        // capability をコードから自動検出。
+        // `export default`（ui:render の自動マウント対象）は globalName バンドル後には
+        // 文字列として残らないため、生ソース（srcCode）も検出対象に含める。
+        const detected = detectCapabilities(`${code}\n${srcCode}`);
         const declaredCapabilities = Array.isArray(config?.capabilities)
             ? (config.capabilities as string[])
             : [];

--- a/packages/sdk/src/ubi/autoRender.test.ts
+++ b/packages/sdk/src/ubi/autoRender.test.ts
@@ -1,0 +1,172 @@
+/**
+ * `Ubi.ui.render` の自動再描画（依存追跡）の統合テスト。
+ * `Ubi.state` と `Ubi.ui` は別モジュールだが、`reactiveTracking` を介して結合する
+ * ため、実際の `UbiSDK` と同じ形で両方を組んでテストする。
+ */
+import type { ComponentInstance } from '@ubichill/shared/mod/entities';
+import { describe, expect, it, vi } from 'vitest';
+import { createStateModule, type StateModuleDeps } from './state';
+import { createUiModule } from './ui';
+
+function makeHarness() {
+    const sent: unknown[] = [];
+    const initialEntities: ComponentInstance[] = [
+        { id: 'ent-1', type: 'thing', entityId: 'go-1', data: {} } as ComponentInstance,
+    ];
+    const isTicking = false;
+
+    const ui = createUiModule(
+        (cmd) => sent.push(cmd),
+        () => isTicking,
+        () => {},
+        () => {},
+    );
+
+    const deps: StateModuleDeps = {
+        send: (cmd) => sent.push(cmd),
+        updateEntity: async () => {},
+        getMyUserId: () => 'me',
+        getEntityId: () => undefined,
+        getModId: () => 'mod',
+        getComponentType: () => undefined,
+        getWatchEntityTypes: () => ['thing'],
+        getPresenceUsers: () => new Map(),
+        getLocalSharedState: () => ({}),
+        getScrollX: () => 0,
+        getScrollY: () => 0,
+        getForEachUserComponents: () => new Set(),
+        registerPendingFlush: () => {},
+        getInitialEntities: () => initialEntities,
+        beginRender: () => {},
+        queueUiRender: ui._queueUiRender,
+        unmountUi: ui._unmountUi,
+        recordUiRenderCost: ui._recordUiRenderCost,
+        buildEntityTargetId: ui._buildEntityTargetId,
+    };
+    const state = createStateModule(deps);
+
+    return { ui, state, sent };
+}
+
+/** UI_RENDER で送られた vnode のうち、直近1件を返す。 */
+function lastRenderedVNode(sent: unknown[], targetId: string): unknown {
+    const matches = sent.filter(
+        (c): c is { type: string; payload: { targetId: string; vnode: unknown } } =>
+            typeof c === 'object' && c !== null && (c as { type?: string }).type === 'UI_RENDER',
+    );
+    return matches.filter((c) => c.payload.targetId === targetId).at(-1)?.payload.vnode;
+}
+
+describe('Ubi.ui.render の自動再描画', () => {
+    it('読んだ state キーが変わると、明示的に呼び直さなくても再描画される', async () => {
+        const { ui, state, sent } = makeHarness();
+        const s = state.define({ color: state.sync('#fff') });
+
+        ui.render(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never, 'target');
+        await Promise.resolve(); // queueMicrotask の flush 待ち
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { color: '#fff' }, children: [] });
+
+        sent.length = 0;
+        s.local.color = '#000';
+        await Promise.resolve();
+
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { color: '#000' }, children: [] });
+    });
+
+    it('factory が読まなかったキーの変化では再描画されない', async () => {
+        const { ui, state, sent } = makeHarness();
+        const s = state.define({ color: state.sync('#fff'), unrelated: state.sync(0) });
+
+        ui.render(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never, 'target');
+        await Promise.resolve();
+        sent.length = 0;
+
+        s.local.unrelated = 42;
+        await Promise.resolve();
+
+        expect(sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER')).toHaveLength(0);
+    });
+
+    it('条件分岐で読むキーが変わる場合、動的に依存を追跡し直す', async () => {
+        const { ui, state, sent } = makeHarness();
+        const s = state.define({ mode: state.sync('a'), a: state.sync(1), b: state.sync(2) });
+
+        const factory = () =>
+            ({ type: 'div', props: { value: s.local.mode === 'a' ? s.local.a : s.local.b }, children: [] }) as never;
+        ui.render(factory, 'target');
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { value: 1 }, children: [] });
+
+        // 現在は mode==='a' なので b の変化は無視されるはず
+        sent.length = 0;
+        s.local.b = 999;
+        await Promise.resolve();
+        expect(sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER')).toHaveLength(0);
+
+        // mode を切り替えると b が依存になり、以後 b の変化で再描画される
+        sent.length = 0;
+        s.local.mode = 'b';
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { value: 999 }, children: [] });
+
+        sent.length = 0;
+        s.local.a = 12345;
+        await Promise.resolve();
+        expect(sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER')).toHaveLength(0);
+    });
+
+    it('unmount すると自動再描画の購読も解除される', async () => {
+        const { ui, state, sent } = makeHarness();
+        const s = state.define({ color: state.sync('#fff') });
+
+        ui.render(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never, 'target');
+        await Promise.resolve();
+
+        ui.unmount('target');
+        await Promise.resolve(); // unmount 自体が積む null-vnode の UI_RENDER を先に flush させる
+        sent.length = 0;
+
+        s.local.color = '#000';
+        await Promise.resolve();
+
+        expect(sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER')).toHaveLength(0);
+    });
+
+    it('明示的な onChange 併用は害にならない（重複呼び出しでも最終送信は最新値の1件）', async () => {
+        const { ui, state, sent } = makeHarness();
+        const s = state.define({ color: state.sync('#fff') });
+        const render = () =>
+            ui.render(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never, 'target');
+        s.onChange('color', render); // 旧パターン: 手動で結線したままでも動く
+        render();
+        await Promise.resolve();
+        sent.length = 0;
+
+        s.local.color = '#abc';
+        await Promise.resolve();
+
+        const renders = sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER');
+        // 手動 onChange + 自動追跡が両方トリガーされても、同一 targetId は Map 上書きで
+        // postMessage は最終的に1回にまとまる。
+        expect(renders).toHaveLength(1);
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { color: '#abc' }, children: [] });
+    });
+
+    it('factory の呼び出し回数でも確認する（無関係なキー変化では再実行されない）', async () => {
+        const { ui, state } = makeHarness();
+        const s = state.define({ color: state.sync('#fff'), unrelated: state.sync(0) });
+        const factory = vi.fn(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never);
+
+        ui.render(factory, 'target');
+        await Promise.resolve();
+        expect(factory).toHaveBeenCalledTimes(1);
+
+        s.local.unrelated = 1;
+        await Promise.resolve();
+        expect(factory).toHaveBeenCalledTimes(1); // 未読のキーなので再実行されない
+
+        s.local.color = '#000';
+        await Promise.resolve();
+        expect(factory).toHaveBeenCalledTimes(2); // 読んだキーなので再実行される
+    });
+});

--- a/packages/sdk/src/ubi/autoRender.test.ts
+++ b/packages/sdk/src/ubi/autoRender.test.ts
@@ -7,6 +7,7 @@ import type { ComponentInstance } from '@ubichill/shared/mod/entities';
 import { describe, expect, it, vi } from 'vitest';
 import { createEventModule } from './event';
 import { createGripModule } from './grip';
+import { createReadTracker } from './reactiveTracking';
 import { createStateModule, type StateModuleDeps } from './state';
 import { createUiModule } from './ui';
 
@@ -16,12 +17,14 @@ function makeHarness() {
         { id: 'ent-1', type: 'thing', entityId: 'go-1', data: {} } as ComponentInstance,
     ];
     const isTicking = false;
+    const readTracker = createReadTracker();
 
     const ui = createUiModule(
         (cmd) => sent.push(cmd),
         () => isTicking,
         () => {},
         () => {},
+        readTracker,
     );
 
     const deps: StateModuleDeps = {
@@ -39,6 +42,7 @@ function makeHarness() {
         getForEachUserComponents: () => new Set(),
         registerPendingFlush: () => {},
         getInitialEntities: () => initialEntities,
+        trackRead: readTracker.recordRead,
         beginRender: () => {},
         queueUiRender: ui._queueUiRender,
         unmountUi: ui._unmountUi,
@@ -59,11 +63,13 @@ function makeHarness() {
 function makeGripHarness() {
     const sent: unknown[] = [];
     const isTicking = false;
+    const readTracker = createReadTracker();
     const ui = createUiModule(
         (cmd) => sent.push(cmd),
         () => isTicking,
         () => {},
         () => {},
+        readTracker,
     );
     const deps: StateModuleDeps = {
         send: (cmd) => sent.push(cmd),
@@ -80,6 +86,7 @@ function makeGripHarness() {
         getForEachUserComponents: () => new Set(),
         registerPendingFlush: () => {},
         getInitialEntities: () => [],
+        trackRead: readTracker.recordRead,
         beginRender: () => {},
         queueUiRender: ui._queueUiRender,
         unmountUi: ui._unmountUi,
@@ -186,14 +193,15 @@ describe('Ubi.ui.render の自動再描画', () => {
         expect(sent.filter((c) => (c as { type?: string }).type === 'UI_RENDER')).toHaveLength(0);
     });
 
-    it('明示的な onChange 併用は害にならない（重複呼び出しでも最終送信は最新値の1件）', async () => {
+    it('明示的な onChange 併用は害にならない（postMessage は最新値の1件だが、factory自体は重複実行される）', async () => {
         const { ui, state, sent } = makeHarness();
         const s = state.define({ color: state.sync('#fff') });
-        const render = () =>
-            ui.render(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never, 'target');
+        const factory = vi.fn(() => ({ type: 'div', props: { color: s.local.color }, children: [] }) as never);
+        const render = () => ui.render(factory, 'target');
         s.onChange('color', render); // 旧パターン: 手動で結線したままでも動く
         render();
         await Promise.resolve();
+        factory.mockClear();
         sent.length = 0;
 
         s.local.color = '#abc';
@@ -204,6 +212,11 @@ describe('Ubi.ui.render の自動再描画', () => {
         // postMessage は最終的に1回にまとまる。
         expect(renders).toHaveLength(1);
         expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { color: '#abc' }, children: [] });
+        // ただし postMessage が1回に集約されるのは queueUiRender の Map 上書きの効果であり、
+        // factory 自体は「手動 onChange」と「自動追跡」の両方から呼ばれるため2回実行される。
+        // factory に副作用がある場合は問題になり得るため、この新パターン移行後は手動 onChange
+        // を削除するのが正しい（pen.worker.tsx で実施した対応）。
+        expect(factory).toHaveBeenCalledTimes(2);
     });
 
     it('factory の呼び出し回数でも確認する（無関係なキー変化では再実行されない）', async () => {
@@ -243,5 +256,58 @@ describe('Ubi.ui.render の自動再描画', () => {
         g.release();
         await Promise.resolve();
         expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { held: false }, children: [] });
+    });
+
+    it('grip.holder / grip.isHeldByOther も同じ Proxy 経路を読むため自動追跡される', async () => {
+        const { ui, grip, state, sent } = makeGripHarness();
+        // acquire する側 (me) と、それを観測する側 (別 targetId で isHeldByOther/holder を見る) を
+        // 同じ grip インスタンスに対して張る。実際の「他人が持っている」を再現するため、
+        // 保持者を送り主の視点ではなく、この grip.holder が返す生の値で検証する。
+        const g = grip.exclusive({ mode: 'manual', bringToFront: false });
+        const factory = vi.fn(
+            () =>
+                ({
+                    type: 'div',
+                    props: { holder: g.holder, heldByOther: g.isHeldByOther },
+                    children: [],
+                }) as never,
+        );
+
+        ui.render(factory, 'target');
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({
+            type: 'div',
+            props: { holder: null, heldByOther: false },
+            children: [],
+        });
+
+        sent.length = 0;
+        g.acquire(); // acquire するのは自分 (me) なので isHeldByOther は false のまま、holder だけ変わる
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({
+            type: 'div',
+            props: { holder: 'me', heldByOther: false },
+            children: [],
+        });
+
+        sent.length = 0;
+        g.release();
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({
+            type: 'div',
+            props: { holder: null, heldByOther: false },
+            children: [],
+        });
+
+        // 他ユーザーが掴んだ場合（ホストからの entity 更新を模す）は isHeldByOther が true になる。
+        sent.length = 0;
+        const [binding] = state._getStateBindings();
+        binding?.applyEntity({ id: 'grip-entity', type: 'thing', lockedBy: 'other-user' } as ComponentInstance);
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({
+            type: 'div',
+            props: { holder: 'other-user', heldByOther: true },
+            children: [],
+        });
     });
 });

--- a/packages/sdk/src/ubi/autoRender.test.ts
+++ b/packages/sdk/src/ubi/autoRender.test.ts
@@ -5,6 +5,8 @@
  */
 import type { ComponentInstance } from '@ubichill/shared/mod/entities';
 import { describe, expect, it, vi } from 'vitest';
+import { createEventModule } from './event';
+import { createGripModule } from './grip';
 import { createStateModule, type StateModuleDeps } from './state';
 import { createUiModule } from './ui';
 
@@ -46,6 +48,58 @@ function makeHarness() {
     const state = createStateModule(deps);
 
     return { ui, state, sent };
+}
+
+/**
+ * grip.isMine 等が state 経由で自動追跡されることを確認するためのハーネス。
+ * getInitialEntities を空にする: makeHarness の fixture entity (type: 'thing') は
+ * grip 内部の state.define({ holder }) の watchType マッチ対象とは無関係だが、
+ * 同じ type 名でマッチしてしまうと holder の初期値（null）が意図せず上書きされてしまうため。
+ */
+function makeGripHarness() {
+    const sent: unknown[] = [];
+    const isTicking = false;
+    const ui = createUiModule(
+        (cmd) => sent.push(cmd),
+        () => isTicking,
+        () => {},
+        () => {},
+    );
+    const deps: StateModuleDeps = {
+        send: (cmd) => sent.push(cmd),
+        updateEntity: async () => {},
+        getMyUserId: () => 'me',
+        getEntityId: () => undefined,
+        getModId: () => 'mod',
+        getComponentType: () => undefined,
+        getWatchEntityTypes: () => [],
+        getPresenceUsers: () => new Map(),
+        getLocalSharedState: () => ({}),
+        getScrollX: () => 0,
+        getScrollY: () => 0,
+        getForEachUserComponents: () => new Set(),
+        registerPendingFlush: () => {},
+        getInitialEntities: () => [],
+        beginRender: () => {},
+        queueUiRender: ui._queueUiRender,
+        unmountUi: ui._unmountUi,
+        recordUiRenderCost: ui._recordUiRenderCost,
+        buildEntityTargetId: ui._buildEntityTargetId,
+    };
+    const state = createStateModule(deps);
+    const event = createEventModule({ send: () => {}, registerSystem: () => {} });
+    const grip = createGripModule({
+        state,
+        event,
+        getMyUserId: () => 'me',
+        getComponentInstanceId: () => 'self-1',
+        getComponentType: () => 'thing',
+        getEntityId: () => 'go-1',
+        listenMouseUp: () => () => {},
+        sendGripCommand: () => {},
+        bringToFront: async () => {},
+    });
+    return { ui, state, grip, sent };
 }
 
 /** UI_RENDER で送られた vnode のうち、直近1件を返す。 */
@@ -168,5 +222,26 @@ describe('Ubi.ui.render の自動再描画', () => {
         s.local.color = '#000';
         await Promise.resolve();
         expect(factory).toHaveBeenCalledTimes(2); // 読んだキーなので再実行される
+    });
+
+    it('grip.isMine は内部で Ubi.state を読むため、明示的な grip.onChange なしでも自動再描画される', async () => {
+        const { ui, grip, sent } = makeGripHarness();
+        const g = grip.exclusive({ mode: 'manual', bringToFront: false });
+        const factory = vi.fn(() => ({ type: 'div', props: { held: g.isMine }, children: [] }) as never);
+
+        // grip.onChange は一切呼ばない。factory 内で g.isMine を読むだけで依存追跡される。
+        ui.render(factory, 'target');
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { held: false }, children: [] });
+
+        sent.length = 0;
+        g.acquire();
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { held: true }, children: [] });
+
+        sent.length = 0;
+        g.release();
+        await Promise.resolve();
+        expect(lastRenderedVNode(sent, 'target')).toEqual({ type: 'div', props: { held: false }, children: [] });
     });
 });

--- a/packages/sdk/src/ubi/index.ts
+++ b/packages/sdk/src/ubi/index.ts
@@ -17,6 +17,7 @@ import type { MediaModule } from './media';
 import { createMediaModule } from './media';
 import type { PlayerModule } from './player';
 import { createPlayerModule } from './player';
+import { createReadTracker } from './reactiveTracking';
 import type { StateModule } from './state';
 import { createStateModule } from './state';
 import type { OmitId, UiRenderCostStat } from './types';
@@ -147,8 +148,12 @@ export class UbiSDK {
         const send = (cmd: OmitId<ModGuestCommand>): void => this._send(cmd);
         const rpc = <T>(cmd: OmitId<ModGuestCommand>): Promise<T> => this._rpc<T>(cmd);
 
+        // Ubi.ui.render の自動再描画（依存追跡）用。ui/state 両モジュールで共有する1個だけ
+        // 生成し deps 経由で配る（モジュール単一状態にしない — reactiveTracking.ts の docstring 参照）。
+        const readTracker = createReadTracker();
+
         this.player = createPlayerModule(send, () => this.myUserId);
-        this.ui = createUiModule(send, () => this._isTicking, _beginRender, _clearTarget);
+        this.ui = createUiModule(send, () => this._isTicking, _beginRender, _clearTarget, readTracker);
         this._world = createWorldModule(send, rpc);
         this.state = createStateModule({
             send,
@@ -165,6 +170,7 @@ export class UbiSDK {
             getForEachUserComponents: () => this.player._getForEachUserComponents(),
             registerPendingFlush: (fn) => this._pendingStateFlushes.add(fn),
             getInitialEntities: () => this._initialEntities,
+            trackRead: readTracker.recordRead,
             beginRender: _beginRender,
             queueUiRender: (targetId, vnode) => this.ui._queueUiRender(targetId, vnode),
             unmountUi: (targetId) => this.ui._unmountUi(targetId),

--- a/packages/sdk/src/ubi/reactiveTracking.test.ts
+++ b/packages/sdk/src/ubi/reactiveTracking.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { createReadTracker, type KeyDescriptor } from './reactiveTracking';
+
+function makeDescriptor(): KeyDescriptor {
+    return { subscribe: () => {}, unsubscribe: () => {} };
+}
+
+describe('createReadTracker', () => {
+    it('追跡中でなければ recordRead は何もしない（例外も投げない）', () => {
+        const tracker = createReadTracker();
+        expect(() => tracker.recordRead(makeDescriptor())).not.toThrow();
+    });
+
+    it('begin→record→end で読んだ descriptor の集合を返す（重複は1つにまとまる）', () => {
+        const tracker = createReadTracker();
+        tracker.beginTrackingReads();
+        const d1 = makeDescriptor();
+        const d2 = makeDescriptor();
+        tracker.recordRead(d1);
+        tracker.recordRead(d2);
+        tracker.recordRead(d1);
+        const result = tracker.endTrackingReads();
+        expect(result.size).toBe(2);
+        expect(result.has(d1)).toBe(true);
+        expect(result.has(d2)).toBe(true);
+    });
+
+    it('スタックが空のまま endTrackingReads を呼ぶと空集合を返す（例外を投げない）', () => {
+        const tracker = createReadTracker();
+        expect(tracker.endTrackingReads()).toEqual(new Set());
+    });
+
+    it('ネストした begin/end はLIFOで独立した集合を保つ', () => {
+        const tracker = createReadTracker();
+        tracker.beginTrackingReads();
+        const outer = makeDescriptor();
+        tracker.recordRead(outer);
+
+        tracker.beginTrackingReads();
+        const inner = makeDescriptor();
+        tracker.recordRead(inner);
+        const innerResult = tracker.endTrackingReads();
+        expect(innerResult.has(inner)).toBe(true);
+        expect(innerResult.has(outer)).toBe(false);
+
+        // 内側の end 後、外側の追跡フレームに戻って続けて記録できる
+        tracker.recordRead(outer);
+        const outerResult = tracker.endTrackingReads();
+        expect(outerResult.has(outer)).toBe(true);
+        expect(outerResult.size).toBe(1);
+    });
+
+    it('end を呼ばずに次の begin を呼んでもクラッシュしない（リーク検知は呼び出し側の責務）', () => {
+        // createReadTracker 自身は try/finally を強制しない薄いスタックであることの確認。
+        // 実際のリーク防止は ui/index.ts の renderUi が try/finally で担う。
+        const tracker = createReadTracker();
+        tracker.beginTrackingReads();
+        tracker.recordRead(makeDescriptor());
+        // end を呼ばずに次の begin ...
+        tracker.beginTrackingReads();
+        const result = tracker.endTrackingReads();
+        expect(result.size).toBe(0); // 新しいフレームは空から始まる
+
+        // 元のフレーム（1件記録済み）がまだスタックに残っている
+        const leaked = tracker.endTrackingReads();
+        expect(leaked.size).toBe(1);
+    });
+
+    it('複数の createReadTracker() インスタンスは互いに独立している（モジュール単一状態ではない）', () => {
+        const a = createReadTracker();
+        const b = createReadTracker();
+
+        a.beginTrackingReads();
+        const da = makeDescriptor();
+        a.recordRead(da);
+
+        // b はまだ begin していないので、a の記録は b に影響しない
+        expect(() => b.recordRead(makeDescriptor())).not.toThrow();
+        expect(b.endTrackingReads().size).toBe(0);
+
+        const resultA = a.endTrackingReads();
+        expect(resultA.size).toBe(1);
+        expect(resultA.has(da)).toBe(true);
+    });
+});

--- a/packages/sdk/src/ubi/reactiveTracking.ts
+++ b/packages/sdk/src/ubi/reactiveTracking.ts
@@ -1,0 +1,33 @@
+/**
+ * `Ubi.ui.render()` の自動再描画のための、最小限の依存追跡ユーティリティ。
+ *
+ * 設計: `Ubi.state` の各 `define()` インスタンスが、キーごとに安定した
+ * {@link KeyDescriptor}（そのキー専用の subscribe/unsubscribe 閉包）を1個だけ生成して
+ * 使い回す。`Ubi.ui.render` は factory() 実行中に読まれた descriptor の集合を集め、
+ * 前回の集合との差分だけ subscribe/unsubscribe することで「読んだキーが変わった時だけ
+ * 再実行される」を実現する（React 等の動的依存追跡と同じ発想）。
+ *
+ * ここにはスタック（同期実行中の「いま追跡中か」を覚えるだけの薄い状態）以外の
+ * ロジックは置かない。実際の購読先（listeners）は各 state インスタンス側が持つ。
+ */
+export interface KeyDescriptor {
+    subscribe(targetId: string, onInvalidate: () => void): void;
+    unsubscribe(targetId: string): void;
+}
+
+const trackingStack: Set<KeyDescriptor>[] = [];
+
+/** 追跡を開始する（ネスト呼び出しに備えてスタックを使う）。 */
+export function beginTrackingReads(): void {
+    trackingStack.push(new Set());
+}
+
+/** 追跡中であれば、読まれた descriptor を記録する（追跡中でなければ何もしない）。 */
+export function recordRead(descriptor: KeyDescriptor): void {
+    trackingStack[trackingStack.length - 1]?.add(descriptor);
+}
+
+/** 追跡を終え、今回読まれた descriptor の集合を返す。 */
+export function endTrackingReads(): Set<KeyDescriptor> {
+    return trackingStack.pop() ?? new Set();
+}

--- a/packages/sdk/src/ubi/reactiveTracking.ts
+++ b/packages/sdk/src/ubi/reactiveTracking.ts
@@ -7,27 +7,39 @@
  * 前回の集合との差分だけ subscribe/unsubscribe することで「読んだキーが変わった時だけ
  * 再実行される」を実現する（React 等の動的依存追跡と同じ発想）。
  *
- * ここにはスタック（同期実行中の「いま追跡中か」を覚えるだけの薄い状態）以外の
- * ロジックは置かない。実際の購読先（listeners）は各 state インスタンス側が持つ。
+ * `createReadTracker()` はスタック（同期実行中の「いま追跡中か」を覚えるだけの薄い状態）
+ * のみを持つファクトリ。モジュールレベルのシングルトンにしない理由: `UbiSDK` は
+ * インスタンスごとに独立した Worker（別 JS realm）で動くため実害は無いが、1つの JS realm に
+ * 複数の `UbiSDK`（テストハーネス等）を作るケースで状態を共有してしまうのは設計として
+ * 不必要な結合。`Ubi.ui`/`Ubi.state` と同じ deps 注入の作法に合わせ、`UbiSDK` の
+ * コンストラクタで1個だけ生成し、両モジュールに配る。
  */
 export interface KeyDescriptor {
     subscribe(targetId: string, onInvalidate: () => void): void;
     unsubscribe(targetId: string): void;
 }
 
-const trackingStack: Set<KeyDescriptor>[] = [];
-
-/** 追跡を開始する（ネスト呼び出しに備えてスタックを使う）。 */
-export function beginTrackingReads(): void {
-    trackingStack.push(new Set());
+export interface ReadTracker {
+    /** 追跡を開始する（ネスト呼び出しに備えてスタックを使う）。 */
+    beginTrackingReads(): void;
+    /** 追跡中であれば、読まれた descriptor を記録する（追跡中でなければ何もしない）。 */
+    recordRead(descriptor: KeyDescriptor): void;
+    /** 追跡を終え、今回読まれた descriptor の集合を返す。 */
+    endTrackingReads(): Set<KeyDescriptor>;
 }
 
-/** 追跡中であれば、読まれた descriptor を記録する（追跡中でなければ何もしない）。 */
-export function recordRead(descriptor: KeyDescriptor): void {
-    trackingStack[trackingStack.length - 1]?.add(descriptor);
-}
+export function createReadTracker(): ReadTracker {
+    const trackingStack: Set<KeyDescriptor>[] = [];
 
-/** 追跡を終え、今回読まれた descriptor の集合を返す。 */
-export function endTrackingReads(): Set<KeyDescriptor> {
-    return trackingStack.pop() ?? new Set();
+    return {
+        beginTrackingReads(): void {
+            trackingStack.push(new Set());
+        },
+        recordRead(descriptor: KeyDescriptor): void {
+            trackingStack[trackingStack.length - 1]?.add(descriptor);
+        },
+        endTrackingReads(): Set<KeyDescriptor> {
+            return trackingStack.pop() ?? new Set();
+        },
+    };
 }

--- a/packages/sdk/src/ubi/state/index.test.ts
+++ b/packages/sdk/src/ubi/state/index.test.ts
@@ -48,6 +48,7 @@ function makeDeps(overrides: Partial<StateModuleDeps> = {}): { deps: StateModule
         getForEachUserComponents: () => new Set(),
         registerPendingFlush: (fn) => flushes.add(fn),
         getInitialEntities: () => initialEntities,
+        trackRead: () => {},
         beginRender: () => {},
         queueUiRender: () => {},
         unmountUi: () => {},

--- a/packages/sdk/src/ubi/state/index.ts
+++ b/packages/sdk/src/ubi/state/index.ts
@@ -1,6 +1,7 @@
 import type { ComponentInstance, EntityPatchPayload } from '@ubichill/shared/mod/entities';
 import { CommandType } from '@ubichill/shared/mod/protocol';
 import type { VNode } from '@ubichill/shared/mod/vnode';
+import { type KeyDescriptor, recordRead } from '../reactiveTracking';
 import type { EntityState, EntityStateFor, PresenceEntry, SendFn, StateBinding } from '../types';
 
 // ── スコープマーカー (このファイル内部のみ) ───────────────────────
@@ -183,6 +184,39 @@ export function createStateModule(deps: StateModuleDeps): StateModule {
         const perUserPersistMine = new Map<string, Record<string, unknown>>();
         const listeners = new Map<string, Set<(next: unknown, prev: unknown) => void>>();
 
+        // ── Ubi.ui.render の自動再描画用: キーごとに安定した KeyDescriptor を使い回す ──
+        // (render 側は「前回読んだ descriptor の集合」と比較するだけで済むように、
+        // 同じキーには常に同じ descriptor オブジェクトを返す)
+        const autoListeners = new Map<string, Map<string, () => void>>(); // key -> targetId -> rerun
+        const keyDescriptors = new Map<string, KeyDescriptor>();
+        const getDescriptor = (key: string): KeyDescriptor => {
+            let d = keyDescriptors.get(key);
+            if (!d) {
+                d = {
+                    subscribe: (targetId, onInvalidate) => {
+                        let byTarget = autoListeners.get(key);
+                        if (!byTarget) {
+                            byTarget = new Map();
+                            autoListeners.set(key, byTarget);
+                        }
+                        byTarget.set(targetId, onInvalidate);
+                    },
+                    unsubscribe: (targetId) => {
+                        autoListeners.get(key)?.delete(targetId);
+                    },
+                };
+                keyDescriptors.set(key, d);
+            }
+            return d;
+        };
+        /** 値変化を、手動 onChange リスナーと自動再描画リスナーの両方へ通知する。 */
+        const notify = (key: string, next: unknown, prev: unknown): void => {
+            const set = listeners.get(key);
+            if (set) for (const fn of set) fn(next, prev);
+            const auto = autoListeners.get(key);
+            if (auto) for (const cb of auto.values()) cb();
+        };
+
         // shared フィールドを localSharedState にシード
         const localSharedState = deps.getLocalSharedState();
         for (const [key, scope] of scopes) {
@@ -237,9 +271,7 @@ export function createStateModule(deps: StateModuleDeps): StateModule {
                 }
                 return;
             }
-            const set = listeners.get(key);
-            if (!set) return;
-            for (const fn of set) fn(next, prev);
+            notify(key, next, prev);
         };
 
         const runBatch = (fn: () => void): void => {
@@ -253,9 +285,7 @@ export function createStateModule(deps: StateModuleDeps): StateModule {
                     batchedFires.clear();
                     for (const [key, { prev, next }] of entries) {
                         if (prev === next) continue;
-                        const set = listeners.get(key);
-                        if (!set) continue;
-                        for (const fn of set) fn(next, prev);
+                        notify(key, next, prev);
                     }
                 }
             }
@@ -370,7 +400,13 @@ export function createStateModule(deps: StateModuleDeps): StateModule {
 
         // local は Proxy — 書き込みでスコープに応じた flush を予約
         const proxy = new Proxy(local, {
-            get: (target, prop) => (typeof prop === 'string' ? target[prop] : undefined),
+            get: (target, prop) => {
+                if (typeof prop !== 'string') return undefined;
+                // Ubi.ui.render の factory() 実行中であれば、このキーを依存として記録する
+                // （render 側が実行後に diff して自動 subscribe/unsubscribe する）。
+                recordRead(getDescriptor(prop));
+                return target[prop];
+            },
             set: (target, prop, value) => {
                 if (typeof prop !== 'string') return false;
                 const prev = target[prop];

--- a/packages/sdk/src/ubi/state/index.ts
+++ b/packages/sdk/src/ubi/state/index.ts
@@ -1,7 +1,7 @@
 import type { ComponentInstance, EntityPatchPayload } from '@ubichill/shared/mod/entities';
 import { CommandType } from '@ubichill/shared/mod/protocol';
 import type { VNode } from '@ubichill/shared/mod/vnode';
-import { type KeyDescriptor, recordRead } from '../reactiveTracking';
+import type { KeyDescriptor } from '../reactiveTracking';
 import type { EntityState, EntityStateFor, PresenceEntry, SendFn, StateBinding } from '../types';
 
 // ── スコープマーカー (このファイル内部のみ) ───────────────────────
@@ -110,6 +110,8 @@ export type StateModuleDeps = {
     getForEachUserComponents(): Set<string>;
     registerPendingFlush(fn: () => void): void;
     getInitialEntities(): ComponentInstance[];
+    /** `Ubi.ui.render` の factory() 実行中であれば、このキーを依存として記録する（reactiveTracking）。 */
+    trackRead(descriptor: KeyDescriptor): void;
     beginRender(targetId: string): void;
     queueUiRender(targetId: string, vnode: VNode | null): void;
     unmountUi(targetId: string): void;
@@ -404,7 +406,7 @@ export function createStateModule(deps: StateModuleDeps): StateModule {
                 if (typeof prop !== 'string') return undefined;
                 // Ubi.ui.render の factory() 実行中であれば、このキーを依存として記録する
                 // （render 側が実行後に diff して自動 subscribe/unsubscribe する）。
-                recordRead(getDescriptor(prop));
+                deps.trackRead(getDescriptor(prop));
                 return target[prop];
             },
             set: (target, prop, value) => {

--- a/packages/sdk/src/ubi/types.ts
+++ b/packages/sdk/src/ubi/types.ts
@@ -47,6 +47,15 @@ export type EntityStateFor<T extends Record<string, unknown>> = {
 
 export interface EntityState<T extends Record<string, unknown>> {
     readonly local: T;
+    /**
+     * 指定ユーザーから見た state のスナップショットを返す。
+     *
+     * **注意（自動追跡の対象外）**: `local` はキー読み取りごとに `Ubi.ui.render` の依存追跡
+     * を行う Proxy だが、`for()` の戻り値は毎回組み立てるプレーンオブジェクトなので、
+     * `render()` の factory 内で `state.for(id).xxx` を読んでも自動再描画のトリガーには
+     * ならない。他ユーザー分の値をリアクティブに描画したい場合は {@link renderForEachUser}
+     * を使うこと（プレゼンス変化ごとに明示的に全ユーザー分を再評価する）。
+     */
     for(userId: string): EntityStateFor<T>;
     onChange<K extends keyof T & string>(key: K, listener: (next: T[K], prev: T[K]) => void): void;
     renderForEachUser(componentName: string, factory: (state: EntityStateFor<T>) => VNode | null): void;

--- a/packages/sdk/src/ubi/ui/index.ts
+++ b/packages/sdk/src/ubi/ui/index.ts
@@ -1,5 +1,6 @@
 import { CommandType } from '@ubichill/shared/mod/protocol';
 import type { VNode } from '@ubichill/shared/mod/vnode';
+import { beginTrackingReads, endTrackingReads, type KeyDescriptor } from '../reactiveTracking';
 import type { SendFn, UiRenderCostStat } from '../types';
 
 type UiRenderStatEntry = {
@@ -18,7 +19,9 @@ export type UiModule = {
     /** 画面に一時的な通知（トースト）を表示する。 */
     showToast(text: string): void;
     /**
-     * 自 Component の UI を描画する。`factory` は VNode を返す関数で、状態変化のたびに再評価される。
+     * 自 Component の UI を描画する。`factory` 実行中に読んだ `Ubi.state` のキーを
+     * 自動で追跡し、そのキーが変わったときだけ `factory` を再実行して再描画する
+     * （読まなかったキーの変化では再描画しない。明示的な `onChange` での再呼び出しは不要）。
      * @param targetId 複数 UI を描き分けるときの識別子（省略時は `'default'`）。
      */
     render(factory: () => VNode, targetId?: string): void;
@@ -54,6 +57,18 @@ export function createUiModule(
     const uiTargetScope = new Map<string, { entityId: string; componentName: string }>();
     const uiRenderStats = new Map<string, UiRenderStatEntry>();
     let uiFlushScheduled = false;
+
+    // ── 自動再描画: targetId ごとに「前回の factory() 実行で読まれた state キー」を覚え、
+    // 差分だけ subscribe/unsubscribe する（読むキーが変わらない限り再登録しない）。
+    const uiAutoDeps = new Map<string, Set<KeyDescriptor>>();
+
+    const reconcileAutoDeps = (targetId: string, next: Set<KeyDescriptor>, rerun: () => void): void => {
+        const prev = uiAutoDeps.get(targetId);
+        if (prev) for (const d of prev) if (!next.has(d)) d.unsubscribe(targetId);
+        for (const d of next) if (!prev?.has(d)) d.subscribe(targetId, rerun);
+        if (next.size > 0) uiAutoDeps.set(targetId, next);
+        else uiAutoDeps.delete(targetId);
+    };
 
     const flushUiRenderQueue = (): void => {
         if (uiRenderQueue.size === 0) return;
@@ -103,13 +118,22 @@ export function createUiModule(
     ): void => {
         const start = performance.now();
         beginRender(targetId);
-        const vnode = factory();
+        beginTrackingReads();
+        let vnode: VNode;
+        try {
+            vnode = factory();
+        } finally {
+            // 今回読まれた state キーが変わったときだけ再登録する（`Ubi.state` 側が
+            // 変化時にこの rerun を呼び直し、そのたびに依存が最新化される）。
+            reconcileAutoDeps(targetId, endTrackingReads(), () => renderUi(factory, targetId, scope));
+        }
         recordUiRenderCost(targetId, performance.now() - start, scope);
         queueUiRender(targetId, vnode);
     };
 
     const unmountUi = (targetId: string): void => {
         clearTarget(targetId);
+        reconcileAutoDeps(targetId, new Set(), () => {});
         queueUiRender(targetId, null);
     };
 

--- a/packages/sdk/src/ubi/ui/index.ts
+++ b/packages/sdk/src/ubi/ui/index.ts
@@ -1,6 +1,6 @@
 import { CommandType } from '@ubichill/shared/mod/protocol';
 import type { VNode } from '@ubichill/shared/mod/vnode';
-import { beginTrackingReads, endTrackingReads, type KeyDescriptor } from '../reactiveTracking';
+import type { KeyDescriptor, ReadTracker } from '../reactiveTracking';
 import type { SendFn, UiRenderCostStat } from '../types';
 
 type UiRenderStatEntry = {
@@ -52,7 +52,9 @@ export function createUiModule(
     getIsTicking: () => boolean,
     beginRender: (targetId: string) => void,
     clearTarget: (targetId: string) => void,
+    readTracker: ReadTracker,
 ): UiModule {
+    const { beginTrackingReads, endTrackingReads } = readTracker;
     const uiRenderQueue = new Map<string, VNode | null>();
     const uiTargetScope = new Map<string, { entityId: string; componentName: string }>();
     const uiRenderStats = new Map<string, UiRenderStatEntry>();

--- a/packages/sdk/test/build-mod.test.ts
+++ b/packages/sdk/test/build-mod.test.ts
@@ -392,6 +392,41 @@ describe('buildMod（新規mod作成パイプライン）', () => {
         expect(distIndex).toEqual([entry]);
         expect(publicIndex).toEqual([entry]);
     });
+
+    it('export default function は globalName 経由でバンドルから取り出せる（sandbox.worker.ts の自動マウント前提）', async () => {
+        const fixture: ModFixture = {
+            packageJson: { name: '@ubichill/mod-default-export', version: '1.0.0' },
+            files: {
+                'view.worker.tsx': [
+                    'import type { ComponentConfig } from "@ubichill/sdk";',
+                    '',
+                    'export const config: ComponentConfig = {',
+                    '    watchScope: "entity",',
+                    '    capabilities: ["ui:render"],',
+                    '};',
+                    '',
+                    'export default function View() {',
+                    '    return <div>hello from default export</div>;',
+                    '}',
+                ].join('\n'),
+            },
+        };
+
+        const { modDir, distDir, publicDir } = buildFixture(fixture);
+        await buildMod(modDir, { distDir, publicDir });
+
+        const lock = JSON.parse(readFileSync(join(distDir, 'v1.0.0', 'lock.json'), 'utf-8'));
+        const workerRelPath = (lock.components['default-export:view'].workerUrl as string).replace(/^\.\//, '');
+        const workerPath = join(distDir, 'v1.0.0', workerRelPath);
+        const workerCode = readFileSync(workerPath, 'utf-8');
+
+        // globalName でバンドルの exports が公開され、.default に関数が入っていることを、
+        // 実際にそのコードを評価して確認する（sandbox.worker.ts と同じ前提の検証）。
+        const exported = new Function(
+            `${workerCode}\nreturn typeof __ubichillModuleExports !== "undefined" ? __ubichillModuleExports : undefined;`,
+        )() as { default?: unknown } | undefined;
+        expect(typeof exported?.default).toBe('function');
+    });
 });
 
 describe('runBuild（CLI エントリポイント: 単一mod repo vs モノレポの自動判別）', () => {

--- a/packages/shared/src/mod/capability.ts
+++ b/packages/shared/src/mod/capability.ts
@@ -151,7 +151,12 @@ export interface CapabilityDetector {
 
 export const CAPABILITY_DETECTORS: readonly CapabilityDetector[] = [
     { cap: 'net:fetch', api: 'Ubi.fetch', test: (c) => /\bUbi\.fetch\b/.test(c) },
-    { cap: 'ui:render', api: 'Ubi.ui.render', test: (c) => /\bUbi\.ui\b/.test(c) },
+    // `export default` は sandbox.worker.ts が自動で Ubi.ui.render() する対象（明示呼び出し不要）。
+    {
+        cap: 'ui:render',
+        api: 'Ubi.ui.render / export default',
+        test: (c) => /\bUbi\.ui\b/.test(c) || /\bexport\s+default\b/.test(c),
+    },
     { cap: 'ui:toast', api: 'Ubi.ui.showToast', test: (c) => /\.showToast\s*\(/.test(c) },
     // scene:read は entity/state を触れば付くベースライン。
     {

--- a/packages/shared/src/mod/protocol.ts
+++ b/packages/shared/src/mod/protocol.ts
@@ -40,6 +40,17 @@ export const PROTOCOL_VERSION = 1;
  */
 export const MIN_COMPATIBLE_PROTOCOL_VERSION = 0;
 
+/**
+ * Worker バンドル (`format: 'iife', globalName: MOD_EXPORTS_GLOBAL_NAME`、
+ * `packages/sdk/cli/build.ts`) が mod の `export` をまとめて公開するグローバル変数名。
+ *
+ * sandbox.worker.ts はmodコード実行後にこの変数の `.default` が関数であれば、
+ * 「UIコンポーネントの既定エクスポート」として自動的に `Ubi.ui.render()` する
+ * （mod開発者が初期レンダーを手動で1回呼ぶ手間を省く）。mod のソースが直接
+ * 書くことのない名前を予約しているだけで、値そのものに意味は持たせない。
+ */
+export const MOD_EXPORTS_GLOBAL_NAME = '__ubichillModuleExports';
+
 export type ProtocolCompatibilityLevel =
     /** 完全互換。 */
     | 'ok'

--- a/worlds/default.lock.json
+++ b/worlds/default.lock.json
@@ -50,7 +50,7 @@
     "pen": {
       "id": "pen",
       "version": "2.0.0",
-      "manifestIntegrity": "sha256-nd7sUSEuI286tavb1U9ttzVLJh+r8vIaDF902MKy/Vw=",
+      "manifestIntegrity": "sha256-1wsLHdrABBlE5IBfXYExB0ZPdpcLOGTsQ3LmUH+mtU8=",
       "components": {
         "pen:canvas": {
           "workerUrl": "./canvas/index.678c7678.js",
@@ -64,8 +64,8 @@
           ]
         },
         "pen:pen": {
-          "workerUrl": "./pen/index.a112fa19.js",
-          "integrity": "sha256-oRL6GVTL0jNSfgUtVCuN+7maZh2epdaOCkycAtb8rKk=",
+          "workerUrl": "./pen/index.b16fca01.js",
+          "integrity": "sha256-sW/KASn7hm0yQVbQAjU4wiL9wp5KNGlhF3cgCxrwfOk=",
           "capabilities": [
             "event:emit",
             "host:message",

--- a/worlds/default.lock.json
+++ b/worlds/default.lock.json
@@ -50,11 +50,11 @@
     "pen": {
       "id": "pen",
       "version": "2.0.0",
-      "manifestIntegrity": "sha256-1wsLHdrABBlE5IBfXYExB0ZPdpcLOGTsQ3LmUH+mtU8=",
+      "manifestIntegrity": "sha256-6+m+7aW2hpC7x7JKMPU/JnrOZnlI+O2YKTUFaIsz240=",
       "components": {
         "pen:canvas": {
-          "workerUrl": "./canvas/index.678c7678.js",
-          "integrity": "sha256-Z4x2eNxBPBCw+Z6nVhFcv0FyB9RAZIK6msojWXxXkGE=",
+          "workerUrl": "./canvas/index.18b57e0a.js",
+          "integrity": "sha256-GLV+Cjp4Ie+T5ZkhJDCirTkVZD2/r9WHINTAkAZSMgI=",
           "capabilities": [
             "canvas:draw",
             "event:broadcast",
@@ -64,8 +64,8 @@
           ]
         },
         "pen:pen": {
-          "workerUrl": "./pen/index.b16fca01.js",
-          "integrity": "sha256-sW/KASn7hm0yQVbQAjU4wiL9wp5KNGlhF3cgCxrwfOk=",
+          "workerUrl": "./pen/index.bfbc2188.js",
+          "integrity": "sha256-v7whiDD2mT0Tcnhv3lSpzyox85h26xrUVvZny367A2E=",
           "capabilities": [
             "event:emit",
             "host:message",
@@ -75,8 +75,8 @@
           ]
         },
         "pen:tray": {
-          "workerUrl": "./tray/index.1a07ce58.js",
-          "integrity": "sha256-GgfOWGPX/S9c3lZhfP5RX7S6Dv8V2mhNBsm16LiC/FQ=",
+          "workerUrl": "./tray/index.e54709da.js",
+          "integrity": "sha256-5UcJ2uebwLhSiAbumNX3HnL0+XGEVykLv3at4pnJZL4=",
           "capabilities": [
             "event:emit",
             "scene:read",

--- a/worlds/default.yaml
+++ b/worlds/default.yaml
@@ -37,7 +37,6 @@ spec:
           components:
             - data:
                 loop: none
-                apiBase: https://videoplayer.youkan.uk
                 shuffle: false
                 duration: 0
                 playlist: []
@@ -57,7 +56,8 @@ spec:
             scale: 1
             rotation: 0
           components:
-            - data: {}
+            - data:
+                apiBase: https://videoplayer.youkan.uk
               type: video-player:controls
         - id: playlist
           tags: []


### PR DESCRIPTION
## 概要
3つの対応をまとめている。

**マージは急ぎません。レビューをお願いします。**

## 1. video-playerのMEDIA_ELEMENT_ERROR

**結論: mod分離が原因ではない。** `Ubi.modBase` は動画URL構築に一切使われておらず、動画URLは`video-player:controls`が`apiBase`（絶対URL）から直接組み立てている。

実測したところ、外部videoplayerバックエンド（`https://videoplayer.youkan.uk`、別ホスト）が `/` は200を返すが `/search`・`/video/{id}` はCloudflareの502を返す状態だった。ブラウザが16バイトのテキスト（`error code: 502`）を動画として読み込もうとして`MEDIA_ELEMENT_ERROR: Format error`になっている。これはこのモノレポの外側（別サーバーの可用性問題）なので、サーバー側のログ確認が必要（`docker logs`/`kubectl logs`）。

調査中に見つけた実際の設定ミスは修正した: `worlds/default.yaml`で`apiBase`が`video-player:screen`のdataに置かれていたが、実際にそれを参照するのは`video-player:controls`。

## 2. Ubi.ui.renderの自動再描画（依存追跡）

`Ubi.ui.render(factory, targetId)`が`factory()`実行中に読んだ`Ubi.state`のキーを自動追跡し、そのキーが変わったときだけ`factory`を再実行するようにした（React/Vue等と同じ動的依存追跡）。読まなかったキーの変化では再描画されないため、**postMessageの送信数は増えない**。既存の手動`onChange(key, render)`を残しても害はない。

## 3. export default による初期レンダーの自動マウント + grip自動追跡の実証

さらに「初回のrender呼び出しも自動化できないか」という要望を受けて、Workerファイルが `export default function() { return <jsx/> }` の形でUIをエクスポートすると、sandbox.worker.ts がmodコード実行後に自動で `Ubi.ui.render(default, 'default')` を1回呼ぶようにした。

- `packages/sdk/cli/build.ts`: esbuildに`globalName`を設定し、Workerの`export`をグローバル変数（`MOD_EXPORTS_GLOBAL_NAME`）経由で公開
- `packages/sandbox/src/worker/sandbox.worker.ts`: modコード実行直後にその`.default`が関数であれば自動render
- `packages/shared/src/mod/capability.ts`: capability自動検出を`export default`パターンにも対応

また「`grip.isMine`はUbi.stateではないので自動追跡の対象外、明示的に結線する」という自分のコメントに対して「非常にややこしくないか」という指摘を受け、実際に検証したところ**これは誤りだった**。`Ubi.grip.exclusive()`の`isMine`/`holder`は内部で`Ubi.state.define({holder})`の`local`プロキシを読んでいるため、既に自動追跡の対象になっている（テストで実証、`packages/sdk/src/ubi/autoRender.test.ts`）。`grip.onChange(renderPen)`も不要と判明したため削除した。

結果として `mods/pen/src/pen.worker.tsx`・`tray.worker.tsx` は `Ubi.ui.render`の明示呼び出しも`onChange`の手動結線も一切不要になり、`export default function` のみになった。

## テスト
- `pnpm lint` / `pnpm typecheck` / `npx vitest run` すべてクリーン（新規テスト: `autoRender.test.ts`に7件、`build-mod.test.ts`にexport default検証を追加）
- `pnpm --filter @ubichill/sdk build` でnpm公開用ビルドも確認
- Playwrightで実ブラウザ確認済み: pen/trayの`export default`自動マウントが正常動作、ペンをgrip acquireすると`grip.isMine`の自動追跡で見た目が変わることを確認（`onChange`結線なしで）、コンソールエラー/警告ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)