### PR TITLE
fix: changesetのパッケージ名をubichillから@ubichill/sdkに修正

### DIFF
--- a/.changeset/reactive-ui-render.md
+++ b/.changeset/reactive-ui-render.md
@@ -1,5 +1,5 @@
 ---
-"ubichill": minor
+"@ubichill/sdk": minor
 ---
 
 `Ubi.ui.render(factory, targetId)` が `factory()` 実行中に読んだ `Ubi.state` のキーを自動追跡し、そのキーが変わったときだけ自動で再描画するようになりました。`state.onChange(key, render)` による手動の再描画結線は不要になります（既存の呼び出しを残しても害はありません）。読まなかったキーの変化では再描画されないため、postMessage の送信数は増えません。


### PR DESCRIPTION
## 概要
2点をまとめている。

## 1. changesetのパッケージ名修正（緊急・リリースフローのブロック解除）
PR #146 で追加した changeset (`reactive-ui-render.md`) のフロントマターが `"ubichill": minor` になっていたが、changesets はワークスペース上の実パッケージ名（`@ubichill/sdk`）を参照するため、CI（`changeset-release/main`）で以下のエラーが発生していた。

```
🦋  error Error: Found changeset reactive-ui-render for package ubichill which is not in the workspace
```

`"ubichill"` はnpm公開時のpublicパッケージ名（`packages/sdk/build.mjs` が publish 時に付け替えるだけ）で、ワークスペースの `package.json` 上の名前ではない。`"@ubichill/sdk": minor` に修正した。

## 2. CI: PR時点でchangesetのパッケージ名を検証するステップを追加（再発防止）
上記の不一致は、mainへのpush後の`changeset-release/main`ジョブでしか発覚せず、リリースフローがブロックされるまで気づけなかった。`lint`ジョブに `npx changeset status` を追加し、PR時点で検証するようにした。

- private packages（backend/db/bff/shared/ecs/loader/ui-renderer）と明示ignore対象（frontend/sandbox/react、`.changeset/config.json`）はchangesets管理対象外なので、実質 `packages/sdk` の変更にchangesetが伴っているかだけを見る
- ローカルで誤検知しないことを確認済み: changesetを外すと`packages/sdk`変更ありの状態で正しく失敗する一方、`mods/pen`等の非対象パッケージのみの変更では反応しない

`npx changeset status` で `@ubichill/sdk` へのminorバンプとして正しく解決されることを確認済み。

このPRはCIブロック解除が主目的で影響が小さいため、確認後にマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)