### PR TITLE
ci: PR時にchangesetのパッケージ名を検証するステップを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
       - name: Lint
         run: pnpm lint
 
+      # .changeset/*.md のフロントマターが実ワークスペースのpackage.json名と一致するかを
+      # PR時点で検証する。ここを飛ばすと不一致は push to main 後の changeset-release/main
+      # ジョブでのみ発覚し、リリースフローがブロックされるまで気づけない
+      # （実際に発生: "ubichill" と書いてしまい実パッケージ名 "@ubichill/sdk" と不一致）。
+      - name: Validate changesets
+        run: npx changeset status
+
   test:
     name: Test & Typecheck
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,18 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          # changeset status が「main からどこで分岐したか」を見るのに履歴が必要
+          # （既定のshallow checkoutだとPRブランチの単一commitしか無く
+          # "Failed to find where HEAD diverged from main" で落ちる）。
+          fetch-depth: 0
+
+      # actions/checkout はチェックアウト対象ブランチのみの制限付き fetch refspec を張るため、
+      # fetch-depth: 0 だけでは origin/main という参照自体が作られない
+      # （実測: refspec が `+refs/heads/<このブランチ>:refs/remotes/origin/<このブランチ>` に
+      # 制限されており、他ブランチは一切フェッチされない）。明示的に origin/main を取得する。
+      - name: Fetch main for changeset diff base
+        run: git fetch origin main:refs/remotes/origin/main
 
       - name: Extract Node version from package.json
         id: versions
@@ -63,8 +75,10 @@ jobs:
       # PR時点で検証する。ここを飛ばすと不一致は push to main 後の changeset-release/main
       # ジョブでのみ発覚し、リリースフローがブロックされるまで気づけない
       # （実際に発生: "ubichill" と書いてしまい実パッケージ名 "@ubichill/sdk" と不一致）。
+      # --since=origin/main で明示する: ローカルに "main" ブランチが無くても
+      # (このジョブではPRブランチしかcheckoutしていない) origin/main の参照だけで解決できる。
       - name: Validate changesets
-        run: npx changeset status
+        run: npx changeset status --since=origin/main
 
   test:
     name: Test & Typecheck


### PR DESCRIPTION
## 概要
PR #147 で追加したはずのCIチェックが、実は squash merge のタイミングの関係でmainに反映されていなかった（コミットが孤立したブランチに取り残されていた）ため、改めてPRを作成する。

## 背景
changesetのフロントマターに実ワークスペースに存在しないパッケージ名（`ubichill` ≠ `@ubichill/sdk`）を書いてしまっても、mainへのpush後の`changeset-release/main`ジョブでしか失敗が発覚せず、リリースフローがブロックされるまで気づけなかった（実際に発生: PR #146）。

## 変更内容
`lint`ジョブに `npx changeset status` を追加し、PR時点で検証するようにした。

- private packages（backend/db/bff/shared/ecs/loader/ui-renderer）と明示ignore対象（frontend/sandbox/react、`.changeset/config.json`）はchangesets管理対象外なので、実質 `packages/sdk` の変更にchangesetが伴っているかだけを見る
- ローカルで誤検知しないことを確認済み: changesetを外すと`packages/sdk`変更ありの状態で正しく失敗する一方、`mods/pen`等の非対象パッケージのみの変更では反応しない

## 補足
PR #148（`chore: version packages`、changesets/actionがGITHUB_TOKENで作成）のようなbotが作るPRは、GitHub Actionsの仕様上GITHUB_TOKEN起点のPRは`pull_request`トリガーを起動しないため、このチェックも走らない。これは既知の制限で対処不要（差分がバージョン番号+CHANGELOGのみの機械的な変更のため実害はない）。

マージ後、確認お願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)